### PR TITLE
TraceLoggingProvider.h - keyword 0, wchar_t, fix C

### DIFF
--- a/include/lttngh/LttngHelpers.h
+++ b/include/lttngh/LttngHelpers.h
@@ -11,7 +11,6 @@
 #include <string.h>                 // strlen
 #include <uchar.h>                  // char16_t
 
-
 // Use lttngh_IP_PARAM to get the address of the caller.
 // (For use as the pCallerIp parameter of lttngh_EventProbe.)
 #undef lttngh_IP_PARAM


### PR DESCRIPTION
Overview:
- Fix compile error under C, where cds_list_head() won't work (for
  multiple reasons).
- Events where keyword == 0 sometimes need to be matched by event
  filters, so add an event suffix ";k;" that means keyword == 0.
- Use the wchar_t support from LttngHelpers.h instead of duplicating.
  This is actually more code than duplicating, but I think it is easier to
  follow and it consolidates the wchar_t handling where it belongs.

Details:
- Instead of having wchar_t be an instance of CharNN, make it a special case
  (like char already is).
- Because char and wchar_t are now more similar, instead of putting macros
  in order char, char16, char32, wchar_t, put them in order char, wchar_t,
  char16, char32.
- Add suffix ";k;" when keyword == 0.
- Add C++ helpers for wchar_t: _tlgCppInit1DescStringW,
  _tlgCppInit1DescSeqWchar, _tlgCppInit1DescWchar.
- Rename C++ helper _tlgCppInit1DescCharUtf16 to _tlgCppInit1DescChar16.
- Rename C++ helper _tlgCppInit1DescCharUtf32 to _tlgCppInit1DescChar32.
- C++ auto helpers can use LttngHelpers functions instead of doing their
  own casting and macro magic.
- Add handlers for the new CharW, StringW, and CountedStringW cases.