### PR TITLE
Improve dependency finding and install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,20 +4,28 @@ project(tracelogging VERSION 0.1)
 
 include(GNUInstallDirs)
 
-add_compile_options(-Wall -Wextra -Werror)
-set(TRACELOGGING_BUILD_TESTS ON CACHE BOOL "Build tests.")
+add_compile_options(-Wall -Wextra)
+
+list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/modules)
+
+find_package(LTTngUST REQUIRED)
+find_package(lttng-ust-tracepoint REQUIRED)
 
 # Include source
 add_subdirectory(src)
 
-# Only include testing stuff if we are the top level
-if(TRACELOGGING_BUILD_TESTS)
+# Only include testing stuff if we are the top level and someone hasn't disabled them explicitly
+option(TRACELOGGING_BUILD_TESTS "Set to OFF to disable building of tests" ON)
+
+if (TRACELOGGING_BUILD_TESTS)
     if (${CMAKE_PROJECT_NAME} STREQUAL ${PROJECT_NAME})
         enable_testing()
 
-        if (NOT TARGET Catch2::Catch2)
+        if (EXISTS ${PROJECT_SOURCE_DIR}/external/Catch2/CMakeLists.txt)
             list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/external/Catch2/contrib")
             add_subdirectory(external/Catch2)
+        else ()
+            find_package(Catch2 REQUIRED)
         endif ()
 
         add_subdirectory(test)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,22 +1,22 @@
 jobs:
   - job: Linux
     pool:
-      vmImage: 'Ubuntu 16.04'
+      vmImage: 'Ubuntu 18.04'
     steps:
     - bash: |
         sudo apt-get update
-        sudo apt-get install g++-4.8 liblttng-ust-dev -y
-      displayName: 'Install dependency packages - test'
+        sudo apt-get install liblttng-ust-dev -y
+      displayName: 'Install dependency packages'
 
     - task: CMake@1
       displayName: 'CMake Configure+Generate'
       inputs:
-        cmakeArgs: '-DCMAKE_C_COMPILER=gcc-4.8 -DCMAKE_CXX_COMPILER=g++-4.8 ..'
+        cmakeArgs: '..'
 
     - task: CMake@1
       displayName: 'CMake Build'
       inputs:
-        cmakeArgs: '--build .'
+        cmakeArgs: '--build . -- -j2'
 
     - bash: |
         cd build/test

--- a/cmake/modules/AliasPkgConfigTarget.cmake
+++ b/cmake/modules/AliasPkgConfigTarget.cmake
@@ -1,0 +1,7 @@
+function(alias_pkg_config_target newTarget targetToClone)
+    add_library(${newTarget} INTERFACE IMPORTED)
+    foreach(name INTERFACE_LINK_LIBRARIES INTERFACE_INCLUDE_DIRECTORIES INTERFACE_COMPILE_DEFINITIONS INTERFACE_COMPILE_OPTIONS)
+        get_property(value TARGET ${targetToClone} PROPERTY ${name})
+        set_property(TARGET ${newTarget} PROPERTY ${name} ${value})
+    endforeach()
+endfunction()

--- a/cmake/modules/Findlttng-ust-tracepoint.cmake
+++ b/cmake/modules/Findlttng-ust-tracepoint.cmake
@@ -1,0 +1,36 @@
+# Output target
+#   lttng-ust-tracepoint::lttng-ust-tracepoint
+
+include(AliasPkgConfigTarget)
+
+if (TARGET lttng-ust-tracepoint::lttng-ust-tracepoint)
+    return()
+endif()
+
+# First try and find with PkgConfig
+find_package(PkgConfig QUIET)
+if (PKG_CONFIG_FOUND)
+    pkg_check_modules(lttng-ust-tracepoint QUIET IMPORTED_TARGET lttng-ust-tracepoint)
+    if (TARGET PkgConfig::lttng-ust-tracepoint)
+        alias_pkg_config_target(lttng-ust-tracepoint::lttng-ust-tracepoint PkgConfig::lttng-ust-tracepoint)
+        return()
+    endif ()
+endif ()
+
+# If that doesn't work, try again with old fashioned path lookup, with some caching
+if (NOT lttng-ust-tracepoint_LIBRARY)
+    find_library(lttng-ust-tracepoint_LIBRARY
+        NAMES lttng-ust-tracepoint)
+
+    include(FindPackageHandleStandardArgs)
+    find_package_handle_standard_args(lttng-ust-tracepoint DEFAULT_MSG
+        lttng-ust-tracepoint_LIBRARY)
+
+    mark_as_advanced(lttng-ust-tracepoint_LIBRARY)
+endif()
+
+add_library(lttng-ust-tracepoint::lttng-ust-tracepoint UNKNOWN IMPORTED)
+set_target_properties(lttng-ust-tracepoint::lttng-ust-tracepoint PROPERTIES
+    IMPORTED_LOCATION "${lttng-ust-tracepoint_LIBRARY}")
+
+set(lttng-ust-tracepoint_FOUND TRUE)

--- a/cmake/modules/traceloggingConfig.cmake
+++ b/cmake/modules/traceloggingConfig.cmake
@@ -1,0 +1,8 @@
+get_filename_component(TRACELOGGING_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+include(CMakeFindDependencyMacro)
+
+find_dependency(LTTngUST REQUIRED)
+
+if (NOT TARGET tracelogging::tracelogging)
+    include("${TRACELOGGING_CMAKE_DIR}/traceloggingTargets.cmake")
+endif ()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,16 +5,14 @@ set(TLG_INCLUDEDIR ${PROJECT_SOURCE_DIR}/include/)
 # Add source to this project's executable.
 add_library(lttngh LttngActivityHelpers.c LttngHelpers.c)
 
-if (NOT CMAKE_VERSION VERSION_LESS 3.8.2)
-    target_compile_features(lttngh PRIVATE c_std_99)
-endif ()
+target_compile_features(lttngh PRIVATE c_std_99)
 
 target_include_directories(lttngh PUBLIC $<INSTALL_INTERFACE:include> $<BUILD_INTERFACE:${TLG_INCLUDEDIR}>)
-target_link_libraries(lttngh PUBLIC lttng-ust lttng-ust-tracepoint)
+target_link_libraries(lttngh PUBLIC LTTng::UST PRIVATE lttng-ust-tracepoint::lttng-ust-tracepoint)
 
 set_property(TARGET lttngh PROPERTY POSITION_INDEPENDENT_CODE ON)
 set_property(TARGET lttngh PROPERTY VERSION "1.0")
-set_property(TARGET lttngh PROPERTY SOVERSION 1)
+set_property(TARGET lttngh PROPERTY SOVERSION 0)
 
 add_library(tracelogging INTERFACE)
 target_include_directories(tracelogging INTERFACE $<INSTALL_INTERFACE:include> $<BUILD_INTERFACE:${TLG_INCLUDEDIR}>)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,8 +11,6 @@ target_include_directories(lttngh PUBLIC $<INSTALL_INTERFACE:include> $<BUILD_IN
 target_link_libraries(lttngh PUBLIC LTTng::UST PRIVATE lttng-ust-tracepoint::lttng-ust-tracepoint)
 
 set_property(TARGET lttngh PROPERTY POSITION_INDEPENDENT_CODE ON)
-set_property(TARGET lttngh PROPERTY VERSION "1.0")
-set_property(TARGET lttngh PROPERTY SOVERSION 0)
 
 add_library(tracelogging INTERFACE)
 target_include_directories(tracelogging INTERFACE $<INSTALL_INTERFACE:include> $<BUILD_INTERFACE:${TLG_INCLUDEDIR}>)
@@ -20,10 +18,24 @@ target_link_libraries(tracelogging INTERFACE lttngh)
 
 set(TARGETLIST tracelogging lttngh)
 
-install(DIRECTORY ${TLG_INCLUDEDIR} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-install(TARGETS ${TARGETLIST} EXPORT tracelogging DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install(DIRECTORY ${TLG_INCLUDEDIR}
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(TARGETS ${TARGETLIST}
+    EXPORT tracelogging-export
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    INCLUDES DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+add_library(tracelogging::tracelogging ALIAS tracelogging)
+
+set(TRACELOGGING_CMAKE_DIR ${CMAKE_INSTALL_LIBDIR}/cmake/tracelogging)
 
 install(
-    EXPORT tracelogging
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/tracelogging
-    FILE traceloggingConfig.cmake)
+    EXPORT tracelogging-export
+    FILE traceloggingTargets.cmake
+    NAMESPACE tracelogging::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/tracelogging)
+
+install(FILES ${PROJECT_SOURCE_DIR}/cmake/modules/traceloggingConfig.cmake
+    DESTINATION ${TRACELOGGING_CMAKE_DIR})


### PR DESCRIPTION
- Remove nonstd::string_view and require C++17
- Allow using Catch2 from install
- Support install of tracelogging better
- Find LTTNG dependencies better
- Change pipeline to 18.04