### PR TITLE
TraceLoggingEventEnabled - fix for events with keywords

### DIFF
--- a/include/tracelogging/TraceLoggingProvider.h
+++ b/include/tracelogging/TraceLoggingProvider.h
@@ -1516,7 +1516,7 @@ Examples:
                 pchEventFullName,
                 pProvider->ProbeDesc.provider, (unsigned)strlen(pProvider->ProbeDesc.provider),
                 eventName, (unsigned)strlen(eventName),
-                0); // Don't add keyword suffix.
+                0) - 3; // Don't add keyword suffix.
 
             for (struct lttng_event_desc const **ppDesc = pEventDescStart; ppDesc != pEventDescStop; ppDesc += 1)
             {


### PR DESCRIPTION
Bug in TraceLoggingEventEnabled that only occurs if the event has a
keyword.

`TraceLoggingEventEnabled(ProviderSymbol, "EventName")` needs to look up
the requested event. Events are identified by a
"ProviderName:EventName;KeywordSuffix" string.

TraceLoggingEventEnabled is supposed to work by creating a
"ProviderName:EventName" string, doing a prefix match on the event, and
if the prefix match succeeds, we check that the next character is a ';'
(meaning we matched up to the keyword prefix) or a 0 (meaning we matched
the full event string).

The bug is that it creates a "ProviderName:EventName;k;" string.
This successfully matches as long as the event has no keywords, but it
incorrectly fails to match if the event does have any keywords.

Fix is to cut off the 3 characters ";k;" after creating the
"ProviderName:EventName;k;" string.