### PR TITLE
Support for lttng-ust 2.13+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.6)
 
 project(tracelogging VERSION 0.2)
 

--- a/README.md
+++ b/README.md
@@ -20,19 +20,19 @@ For example:
 ```cpp
 // Provider UUID: 22731e9c-e31a-4484-98d6-efa23d791456
 TRACELOGGING_DEFINE_PROVIDER(
-    g_providerHandle,
-    // By contention: "Company.Organization.Team.ProviderName"
-    "Microsoft.Windows.Fundamentals.TestProvider",
+    WidgetProvider,
+    // By convention: "Company.Organization.Team.Component"
+    "Microsoft.Windows.Fundamentals.Widget",
     (0x7ea733d9, 0xf4eb, 0x4593, 0x8a, 0x8a, 0x8f, 0x9e, 0x75, 0xb0, 0x80, 0x04));
 
-TraceLoggingRegister(g_providerHandle);
+TraceLoggingRegister(WidgetProvider);
 
 int x = 5;
-TraceLoggingWrite(g_providerHandle,
+TraceLoggingWrite(WidgetProvider,
     "TestEvent", // Event name
     TraceLoggingValue(x, "xValue"));
 
-TraceLoggingUnregister(g_providerHandle);
+TraceLoggingUnregister(WidgetProvider);
 ```
 
 ### Logging LTTNG events through TraceLogging API
@@ -44,7 +44,7 @@ Below is an example of logging a more complex event:
 
 ```cpp
 TraceLoggingWrite(
-    g_providerHandle,
+    WidgetProvider,
     "FinishUpload",
     TraceLoggingKeyword(KeywordEnum::Uploader),
     TraceLoggingLevel(WINEVENT_LEVEL_INFO),
@@ -59,10 +59,10 @@ To consume TraceLogging events sent through LTTNG, you will need the lttng-tools
 
 ```bash
 lttng create
-lttng enable-event -u Microsoft.Windows.Fundamentals.TestProvider.*
+lttng enable-event -u Microsoft.Windows.Fundamentals.TestProvider:*
 lttng start
 
-read -p "Emit events here..."
+read -p "Run your program here..."
 
 lttng stop
 lttng view
@@ -72,7 +72,16 @@ For more information, see the [LTTNG Documentation](https://lttng.org/docs/v2.10
 
 ## Dependencies
 
-This project carries a dependency on the lttng-ust library. To use this library, you will need liblttng-ust-dev >= 2.10. The library will compile with 2.7, but this is currently considered experimental. To get liblttng-ust-dev 2.10:
+This project depends on the lttng-ust library. To build this library, you will need liblttng-ust-dev version 2.10 or later.
+The library will compile with 2.7 or later, but some things might not work perfectly. The library has been tested up through
+version 2.13.)
+
+```bash
+sudo apt update
+sudo apt install liblttng-ust-dev
+```
+
+If your normal package repository uses an older version of LTTNG, consider using the ppa:lttng/stable-2.10 repository to get LTTNG 2.10:
 
 ```bash
 sudo apt-add-repository ppa:lttng/stable-2.10 -y
@@ -80,10 +89,11 @@ sudo apt -y update
 sudo apt install liblttng-ust-dev
 ```
 
-To listen to TraceLogging events, you will need lttng-tools. Note that this is not required to emit events.
+To listen to TraceLogging events, you will need lttng-tools. Note that the tools are required for event collection
+but are not required for your program to run.
 
 ```bash
-sudo apt-get install lttng-tools
+sudo apt install lttng-tools
 ```
 
 ## Integration

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ For more information, see the [LTTNG Documentation](https://lttng.org/docs/v2.10
 
 This project depends on the lttng-ust library. To build this library, you will need liblttng-ust-dev version 2.10 or later.
 The library will compile with 2.7 or later, but some things might not work perfectly. The library has been tested up through
-version 2.13.)
+version 2.13.
 
 ```bash
 sudo apt update

--- a/include/lttngh/LttngHelpers.h
+++ b/include/lttngh/LttngHelpers.h
@@ -197,8 +197,8 @@ extern const struct lttng_ust_type_sequence lttngh_TypeHexInt64Sequence;
 //extern const struct lttng_ust_type_sequence lttngh_TypeFloat32Sequence; // LTTNG array of float is broken.
 //extern const struct lttng_ust_type_sequence lttngh_TypeFloat64Sequence; // LTTNG array of float is broken.
 
-extern const struct lttng_ust_type_sequence lttngh_TypeBool8Sequence;  // LTTNG sequence of enum is broken. Using UInt8[] instead.
-extern const struct lttng_ust_type_sequence lttngh_TypeBool32Sequence; // LTTNG sequence of enum is broken. Using Int32[] instead.
+#define lttngh_TypeBool8Sequence            lttngh_TypeUInt8Sequence   // LTTNG sequence of enum is broken. Using UInt8[] instead.
+#define lttngh_TypeBool32Sequence           lttngh_TypeInt32Sequence   // LTTNG sequence of enum is broken. Using Int32[] instead.
 
 extern const struct lttng_ust_type_string   lttngh_TypeUtf8String;
 extern const struct lttng_ust_type_sequence lttngh_TypeUtf8Sequence;
@@ -532,7 +532,7 @@ enum lttngh_DataType {
   //   in the field's lttng_type.u.array.length value and must also be
   //   provided in the DataDesc.Length value.
   // - For atype_sequence, a sequence is expressed by two DataDesc items.
-  //   The first DataDesc is created via DataDescCreate with Type = Unsigned
+  //   The first DataDesc is created via DataDescCreate with Type = SequenceLength
   //   and contains the sequence's length (number of elements). The second
   //   DataDesc is created via DataDescCreateCounted and contains the data.
   lttngh_DataType_Counted,
@@ -546,7 +546,7 @@ enum lttngh_DataType {
 
   // UTF-16 (host-endian) string data that will be transcoded into a UTF-8
   // sequence before storage into the log. Unlike a normal sequence (where
-  // length is given in a DataDesc with Type = None and content is given in
+  // length is given in a DataDesc with Type = SequenceLength and content is given in
   // a separate DataDesc with Type = Counted), this DataType requires a
   // single DataDesc, which will be transcoded into payload corresponding to
   // a UTF-8 sequence (including both the length and content).
@@ -571,7 +571,7 @@ enum lttngh_DataType {
 
   // UTF-32 (host-endian) string data that will be transcoded into a UTF-8
   // sequence before storage into the log. Unlike a normal sequence (where
-  // length is given in a DataDesc with Type = None and content is given in
+  // length is given in a DataDesc with Type = SequenceLength and content is given in
   // a separate DataDesc with Type = Counted), this DataType requires a
   // single DataDesc, which will be transcoded into payload corresponding to
   // a UTF-8 sequence (including both the length and content).
@@ -600,7 +600,12 @@ enum lttngh_DataType {
   // Floating-point (host-endian): atype_float.
   lttngh_DataType_Float = __FLOAT_WORD_ORDER == __LITTLE_ENDIAN
                               ? lttngh_DataType_FloatLE
-                              : lttngh_DataType_FloatBE
+                              : lttngh_DataType_FloatBE,
+
+  // Use for the length field of a sequence.
+  lttngh_DataType_SequenceLength = lttngh_UST_VER >= 213
+                                    ? lttngh_DataType_None
+                                    : lttngh_DataType_Unsigned
 };
 
 /*

--- a/include/tracelogging/TraceLoggingProvider.h
+++ b/include/tracelogging/TraceLoggingProvider.h
@@ -66,6 +66,7 @@ TraceLoggingProvider.h for LTTNG behaves differently from the ETW version:
     under LTTNG.
   - In TraceLoggingProvider.h for LTTNG, the default level is "debug" (14).
     In TraceLoggingProvider.h for ETW, the default level is "verbose" (5).
+  - For portability, use the TRACE_LEVEL macros defined in LttngHelpers.h.
 - Limited support for TraceLoggingKeyword. TraceLoggingKeyword adds a suffix
   to the event name for each enabled keyword so that you can filter events
   based on the suffix, e.g. keyword 0x5 will turn into suffix ";k0;k2;".
@@ -109,7 +110,7 @@ TraceLoggingProvider.h for LTTNG behaves differently from the ETW version:
 - No support for TraceLoggingPacked macros.
 - No support for TraceLoggingFloat*Array macros.
 - No support for TraceLoggingAnsiString, TraceLoggingUnicodeString (i.e. the
-  NT kernel ANSI_STRING and UNICODE_STRING structures). Could be added.
+  Windows ANSI_STRING and UNICODE_STRING structures).
 - Characters and strings of char16_t, char32_t, or wchar_t will be transcoded
   to UTF-8 before being written to the trace. To support non-ASCII data, a
   char16/char32/wchar will transcode into a variable-length UTF-8 string.
@@ -126,23 +127,13 @@ following issues:
 - Support for TraceLoggingStruct.
 - Support for TraceLoggingFloat*Array macros (i.e. support for
   array/sequence of floats).
-- Support for keywords.
-- Support for better formatting of GUID and timestamp fields.
+- Support for better handling of keywords.
+- Support for better formatting of GUID, timestamp, and IP address fields.
 - Support for better handling of activity IDs.
 - Support for traditional ETW metadata such as provider id, opcode, channel,
   event tag, field tag.
 
 Open questions:
-- Any better way to encode GUID in the trace to make it decode more nicely?
-  Currently, GUID logs as array-of-HexInt8, which looks awful when decoded.
-  Once LTTNG adds support for struct, we can do better, but until then should
-  we do something special such as converting them to string before logging?
-  (Note: not practical to convert array-of-guid to a string.)
-- Is there a GUID struct definition we should be using? Note that uint8_t[16]
-  is not specific enough to be used with TraceLoggingValue -- we need a struct
-  of some kind.
-- Should there be more-specific type checking for FILETIME, SYSTEMTIME, SID?
-  Currently we just accept anything.
 - Do we even care about FILETIME, SYSTEMTIME, SID on Linux?
 - Are there important Linux types that deserve first-class support? (Probably
   not worth worrying about until LTTNG adds support for struct.)
@@ -192,53 +183,45 @@ Do not use these directly. Use wrapper macros such as TraceLoggingInt32.
 These handler macros may be renamed or removed in future versions of this header.
 */
 #define _tlg_ArgIgnored() \
-    (_tlg_Ignored)
+         (_tlg_Ignored)
 #define _tlg_ArgLevel(eventLevel) \
-    (_tlg_Level, eventLevel)
+         (_tlg_Level, eventLevel)
 #define _tlg_ArgKeyword(eventKeyword) \
-    (_tlg_Keyword, eventKeyword)
-#define _tlg_ArgInt(ctype, value, intFieldType, isSigned, ndt) \
-    (_tlg_Int, ctype, value, intFieldType, isSigned, ndt)
-#define _tlg_ArgEnum(ctype, value, intFieldType, isSigned, ndt, etype) \
-    (_tlg_Enum, ctype, value, etype, intFieldType, isSigned, ndt) // Note: parameter reordered for aesthetic reasons.
-#define _tlg_ArgIntArrayByRef(ctype, value, cValues, intFieldType, isSigned, ndt) \
-    (_tlg_IntArrayByRef, ctype, value, cValues, intFieldType, isSigned, ndt)
-#define _tlg_ArgIntArray(ctype, pValues, cValues, intFieldType, isSigned, ndt) \
-    (_tlg_IntArray, ctype, pValues, cValues, intFieldType, isSigned, ndt)
-#define _tlg_ArgIntFixedArray(ctype, pValues, cValues, intFieldType, isSigned, ndt) \
-    (_tlg_IntFixedArray, ctype, pValues, cValues, intFieldType, isSigned, ndt)
-#define _tlg_ArgFloat(ctype, value, ndt) \
-    (_tlg_Float, ctype, value, ndt)
-#define _tlg_ArgFloatArray(ctype, pValues, cValues, ndt) \
-    (_tlg_FloatArray, ctype, pValues, cValues, ndt)
-#define _tlg_ArgFloatFixedArray(ctype, pValues, cValues, ndt) \
-    (_tlg_FloatFixedArray, ctype, pValues, cValues, ndt)
+         (_tlg_Keyword, eventKeyword)
+#define _tlg_ArgScalar(ctype, value, scalarUstType, dataType, ndt) \
+         (_tlg_Scalar, ctype, value, scalarUstType, dataType, ndt)
+#define _tlg_ArgScalarByRef(ctype, value, cValues, arrayUstType, ndt) \
+         (_tlg_ScalarByRef, ctype, value, cValues, arrayUstType, ndt) // ByRef scalars (e.g. GUID, SYSTEMTIME) are logged as array-of-intNN.
+#define _tlg_ArgVarArray(ctype, pValues, cValues, sequenceUstType, ndt) \
+         (_tlg_VarArray, ctype, pValues, cValues, sequenceUstType, ndt) // Requires a precomposed sequenceUstType.
+#define _tlg_ArgFixedArray(ctype, pValues, cValues, elementUstType, ndt) \
+         (_tlg_FixedArray, ctype, pValues, cValues, elementUstType, ndt) // Will compose an array type = elementUstType + cValues.
 #define _tlg_ArgChar8(ctype, value, ndt) \
-    (_tlg_Char8, ctype, value, ndt)
+         (_tlg_Char8, ctype, value, ndt) // Logged as utf8char[1].
 #define _tlg_ArgCharW(ctype, value, ndt) \
-    (_tlg_CharW, ctype, value, ndt)
+         (_tlg_CharW, ctype, value, ndt) // Logged as utf8char[N] (transcoded).
 #define _tlg_ArgCharNN(ctype, value, NN, ndt) \
-    (_tlg_CharNN, ctype, value, NN, ndt)
+         (_tlg_CharNN, ctype, value, NN, ndt) // Logged as utf8char[N] (transcoded).
 #define _tlg_ArgString8(ctype, pszValue, ndt) \
-    (_tlg_String8, ctype, pszValue, ndt)
+         (_tlg_String8, ctype, pszValue, ndt) // Logged as szUtf8.
 #define _tlg_ArgStringW(ctype, pszValue, ndt) \
-    (_tlg_StringW, ctype, pszValue, ndt)
+         (_tlg_StringW, ctype, pszValue, ndt) // Logged as szUtf8 (transcoded).
 #define _tlg_ArgStringNN(ctype, pszValue, NN, ndt) \
-    (_tlg_StringNN, ctype, pszValue, NN, ndt)
+         (_tlg_StringNN, ctype, pszValue, NN, ndt) // Logged as szUtf8 (transcoded).
 #define _tlg_ArgCountedString8(ctype, pchValue, cchValue, ndt) \
-    (_tlg_CountedString8, ctype, pchValue, cchValue, ndt)
+         (_tlg_CountedString8, ctype, pchValue, cchValue, ndt) // Logged as utf8char[N].
 #define _tlg_ArgCountedStringW(ctype, pchValue, cchValue, ndt) \
-    (_tlg_CountedStringW, ctype, pchValue, cchValue, ndt)
+         (_tlg_CountedStringW, ctype, pchValue, cchValue, ndt) // Logged as utf8char[N] (transcoded).
 #define _tlg_ArgCountedStringNN(ctype, pchValue, cchValue, NN, ndt) \
-    (_tlg_CountedStringNN, ctype, pchValue, cchValue, NN, ndt)
+         (_tlg_CountedStringNN, ctype, pchValue, cchValue, NN, ndt) // Logged as utf8char[N] (transcoded).
 #define _tlg_ArgBinary(ctype, pValue, cbValue, ndt) \
-    (_tlg_Binary, ctype, pValue, cbValue, ndt)
+         (_tlg_Binary, ctype, pValue, cbValue, ndt) // Logged as hexint8[N]
 #define _tlg_ArgSid(ctype, pValue, ndt) \
-    (_tlg_Sid, ctype, pValue, ndt)
-#define _tlg_ArgGuidPtr(ctype, pValue, name) \
-    (_tlg_GuidPtr, ctype, pValue, name) // Accepts NULL. Supports RelatedActivityId.
+         (_tlg_Sid, ctype, pValue, ndt) // Logged as hexint8[N]. N determined from SID length.
+#define _tlg_ArgActivityId(ctype, pValue, name) \
+         (_tlg_ActivityId, ctype, pValue, name) // Logged as hexint8[N]. Accepts NULL. Supports RelatedActivityId.
 #define _tlg_ArgBuffer(ctype, pValue, ndt) \
-    (_tlg_Buffer, ctype, pValue, ndt)
+         (_tlg_Buffer, ctype, pValue, ndt) // Logged as hexint8[N]. Data = pValue->Buffer, N = pValue->Length.
 
 #ifdef __EDG__
 #pragma endregion
@@ -273,12 +256,12 @@ A symbol declared by TRACELOGGING_DECLARE_PROVIDER must later be defined in a
 .c or .cpp file using the TRACELOGGING_DEFINE_PROVIDER macro.
 */
 #define TRACELOGGING_DECLARE_PROVIDER(providerSymbol)                                                                                                                 \
-    _tlg_EXTERN_C struct lttng_ust_tracepoint *__start___tracepoints_ptrs_##providerSymbol[] __attribute__((weak, visibility("hidden")));                             \
-    _tlg_EXTERN_C struct lttng_ust_tracepoint *__stop___tracepoints_ptrs_##providerSymbol[] __attribute__((weak, visibility("hidden")));                              \
-    _tlg_EXTERN_C struct lttng_event_desc const *__start___eventdesc_ptrs_##providerSymbol[] __attribute__((weak, visibility("hidden")));                             \
-    _tlg_EXTERN_C struct lttng_event_desc const *__stop___eventdesc_ptrs_##providerSymbol[] __attribute__((weak, visibility("hidden")));                              \
+    _tlg_EXTERN_C struct lttng_ust_tracepoint *_tlg_PASTE(__start___tracepoints_ptrs_, providerSymbol)[] __attribute__((weak, visibility("hidden")));                             \
+    _tlg_EXTERN_C struct lttng_ust_tracepoint *_tlg_PASTE(__stop___tracepoints_ptrs_, providerSymbol)[] __attribute__((weak, visibility("hidden")));                              \
+    _tlg_EXTERN_C lttngh_ust_event_desc const *_tlg_PASTE(__start___eventdesc_ptrs_, providerSymbol)[] __attribute__((weak, visibility("hidden")));                             \
+    _tlg_EXTERN_C lttngh_ust_event_desc const *_tlg_PASTE(__stop___eventdesc_ptrs_, providerSymbol)[] __attribute__((weak, visibility("hidden")));                              \
     _tlg_EXTERN_C struct TraceLoggingProviderSymbol providerSymbol __attribute__((visibility("hidden"))); /* Empty provider variable to help with code navigation. */ \
-    _tlg_EXTERN_C struct _tlg_Provider_t _tlgProv_##providerSymbol __attribute__((visibility("hidden")))  /* Actual provider variable is hidden behind prefix. */
+    _tlg_EXTERN_C struct _tlg_Provider_t _tlg_PASTE(_tlgProv_, providerSymbol) __attribute__((visibility("hidden")))  /* Actual provider variable is hidden behind prefix. */
 
 /*
 Macro TRACELOGGING_DEFINE_PROVIDER(providerSymbol, "ProviderName", providerId, [option]):
@@ -318,9 +301,9 @@ LTTNG-specific:
 */
 #define TRACELOGGING_DEFINE_PROVIDER(providerSymbol, providerName, providerId, ...)                 \
     TRACELOGGING_DECLARE_PROVIDER(providerSymbol);                                                  \
-    static_assert(sizeof("" providerName) <= LTTNG_UST_SYM_NAME_LEN - 6,                            \
+    static_assert(sizeof("" providerName) <= lttngh_UST_SYM_NAME_LEN - 6,                           \
                   "TRACELOGGING_DEFINE_PROVIDER providerName must be no more than 250 characters"); \
-    _tlgParseProviderId(providerId) struct _tlg_Provider_t _tlgProv_##providerSymbol = {{("" providerName), NULL, 0, {NULL,NULL}, {NULL,NULL}, 0, LTTNG_UST_PROVIDER_MAJOR, LTTNG_UST_PROVIDER_MINOR, {}}, 0}
+    _tlgParseProviderId(providerId) struct _tlg_Provider_t _tlg_PASTE(_tlgProv_, providerSymbol) = {lttngh_INIT_PROBE_DESC(("" providerName)), lttngh_REGISTRATION_INIT}
 
 /*
 Macro TraceLoggingOptionGroup(g1, g2, g3, g4, g5, g6, g7, g8, g9, g10, g11):
@@ -367,7 +350,7 @@ has been uninitialized and then reinitialized. You should not register and
 unregister a provider each time you need to write a few events.
 */
 #define TraceLoggingUnregister(providerSymbol) _tlg_ProviderUnregister( \
-    &_tlgProv_##providerSymbol, __start___tracepoints_ptrs_##providerSymbol)
+    &_tlg_PASTE(_tlgProv_, providerSymbol), _tlg_PASTE(__start___tracepoints_ptrs_, providerSymbol))
 
 /*
 Macro TraceLoggingRegister(providerSymbol):
@@ -384,9 +367,9 @@ Note that it is ok to ignore failure - if TraceLoggingRegister fails,
 TraceLoggingWrite and TraceLoggingUnregister will be no-ops.
 */
 #define TraceLoggingRegister(providerSymbol) _tlg_ProviderRegister(                          \
-    &_tlgProv_##providerSymbol,                                                              \
-    __start___tracepoints_ptrs_##providerSymbol, __stop___tracepoints_ptrs_##providerSymbol, \
-    __start___eventdesc_ptrs_##providerSymbol, __stop___eventdesc_ptrs_##providerSymbol)
+    &_tlg_PASTE(_tlgProv_, providerSymbol),                                                              \
+    _tlg_PASTE(__start___tracepoints_ptrs_, providerSymbol), _tlg_PASTE(__stop___tracepoints_ptrs_, providerSymbol), \
+    _tlg_PASTE(__start___eventdesc_ptrs_, providerSymbol), _tlg_PASTE(__stop___eventdesc_ptrs_, providerSymbol))
 
 /*
 Macro TraceLoggingEventEnabled(providerSymbol, "EventName"):
@@ -396,11 +379,11 @@ Returns true (non-zero) if the specified event is enabled.
     ({                                                                                                 \
         static int const *_tlg_pState;                                                                 \
         caa_likely(_tlg_pState)                                                                        \
-            ? caa_unlikely(CMM_LOAD_SHARED(*_tlg_pState))                                              \
-            : caa_unlikely(_tlg_EventEnabled(                                                          \
-                  &_tlgProv_##providerSymbol,                                                          \
+            ? (int)caa_unlikely(CMM_LOAD_SHARED(*_tlg_pState))                                              \
+            : (int)caa_unlikely(_tlg_EventEnabled(                                                          \
+                  &_tlg_PASTE(_tlgProv_, providerSymbol),                                                          \
                   ("" eventName),                                                                      \
-                  __start___eventdesc_ptrs_##providerSymbol, __stop___eventdesc_ptrs_##providerSymbol, \
+                  _tlg_PASTE(__start___eventdesc_ptrs_, providerSymbol), _tlg_PASTE(__stop___eventdesc_ptrs_, providerSymbol), \
                   &_tlg_pState));                                                                      \
     })
 
@@ -409,7 +392,7 @@ Macro TraceLoggingProviderName(providerSymbol):
 Returns the provider's name as a nul-terminated const char*.
 */
 #define TraceLoggingProviderName(providerSymbol) \
-    _tlg_ProviderName(&_tlgProv_##providerSymbol)
+    _tlg_ProviderName(&_tlg_PASTE(_tlgProv_, providerSymbol))
 
 /*
 Macro TraceLoggingWrite(providerSymbol, "EventName", args...):
@@ -438,7 +421,7 @@ LTTNG-specific:
 #define TraceLoggingWrite(providerSymbol, eventName, ...)                                  \
     _tlg_Write_imp(lttngh_EventProbe,                                                      \
                    providerSymbol, eventName,                                              \
-                   _tlg_ArgGuidPtr(void, lttngh_ActivityIdFilter(NULL), "_ms_ActivityId"), \
+                   _tlg_ArgActivityId(void, lttngh_ActivityIdFilter(NULL), "_ms_ActivityId"), \
                    ##__VA_ARGS__)
 
 /*
@@ -449,7 +432,7 @@ Example:
 
     TraceLoggingWriteActivity(MyProvider, "MyEventName",
         pActivityGuid,
-        pRelatedActivityGuid, // Usually NULL (non-NULL for opcode START).
+        pRelatedActivityGuid, // Usually NULL (non-NULL only when used with opcode START).
         TraceLoggingOpcode(WINEVENT_OPCODE_START),
         TraceLoggingInt32(myIntVar),
         TraceLoggingWideString(myString));
@@ -473,8 +456,8 @@ LTTNG-specific:
 #define TraceLoggingWriteActivity(providerSymbol, eventName, pActivityId, pRelatedActivityId, ...) \
     _tlg_Write_imp(lttngh_EventProbe,                                                              \
                    providerSymbol, eventName,                                                      \
-                   _tlg_ArgGuidPtr(void, lttngh_ActivityIdFilter(pActivityId), "_ms_ActivityId"),  \
-                   _tlg_ArgGuidPtr(void, pRelatedActivityId, "_ms_RelatedActivityId"),             \
+                   _tlg_ArgActivityId(void, lttngh_ActivityIdFilter(pActivityId), "_ms_ActivityId"),  \
+                   _tlg_ArgActivityId(void, pRelatedActivityId, "_ms_RelatedActivityId"),             \
                    ##__VA_ARGS__)
 
 /*
@@ -659,7 +642,7 @@ LTTNG-specific:
 - Violations of these rules cannot be detected by TraceLoggingProvider.h, but
   will likely cause problems when you try to decode the trace.
 - Be especially careful with automatically-generated field names, as they
-  often contain spaces other problematic symbols.
+  often contain spaces or other problematic symbols.
 
 If provided, the description parameter must be a string literal.
 (Field description is ignored for LTTNG.)
@@ -717,7 +700,7 @@ LTTNG-specific:
 - Violations of these rules cannot be detected by TraceLoggingProvider.h, but
   will likely cause problems when you try to decode the trace.
 - Be especially careful with automatically-generated field names, as they
-  often contain spaces other problematic symbols.
+  often contain spaces or other problematic symbols.
 
 If provided, the description parameter must be a string literal.
 (Field description is ignored for LTTNG.)
@@ -741,44 +724,44 @@ Examples:
 - TraceLoggingInt32(val1, "name", "desc")      // field name = "name", description = "desc", tags = 0.
 - TraceLoggingInt32(val1, "name", "desc", 0x4) // field name = "name", description = "desc", tags = 0x4.
 */
-#define TraceLoggingInt8(value, ...) _tlg_ArgInt(int8_t, value, _tlgDecimal, 1, _tlg_NDT(TraceLoggingInt8, value, __VA_ARGS__))
-#define TraceLoggingUInt8(value, ...) _tlg_ArgInt(uint8_t, value, _tlgDecimal, 0, _tlg_NDT(TraceLoggingUInt8, value, __VA_ARGS__))
-#define TraceLoggingInt16(value, ...) _tlg_ArgInt(int16_t, value, _tlgDecimal, 1, _tlg_NDT(TraceLoggingInt16, value, __VA_ARGS__))
-#define TraceLoggingUInt16(value, ...) _tlg_ArgInt(uint16_t, value, _tlgDecimal, 0, _tlg_NDT(TraceLoggingUInt16, value, __VA_ARGS__))
-#define TraceLoggingInt32(value, ...) _tlg_ArgInt(int32_t, value, _tlgDecimal, 1, _tlg_NDT(TraceLoggingInt32, value, __VA_ARGS__))
-#define TraceLoggingUInt32(value, ...) _tlg_ArgInt(uint32_t, value, _tlgDecimal, 0, _tlg_NDT(TraceLoggingUInt32, value, __VA_ARGS__))
-#define TraceLoggingLong(value, ...) _tlg_ArgInt(long, value, _tlgDecimal, 1, _tlg_NDT(TraceLoggingLong, value, __VA_ARGS__))
-#define TraceLoggingULong(value, ...) _tlg_ArgInt(unsigned long, value, _tlgDecimal, 0, _tlg_NDT(TraceLoggingULong, value, __VA_ARGS__))
-#define TraceLoggingInt64(value, ...) _tlg_ArgInt(int64_t, value, _tlgDecimal, 1, _tlg_NDT(TraceLoggingInt64, value, __VA_ARGS__))
-#define TraceLoggingUInt64(value, ...) _tlg_ArgInt(uint64_t, value, _tlgDecimal, 0, _tlg_NDT(TraceLoggingUInt64, value, __VA_ARGS__))
-#define TraceLoggingHexInt8(value, ...) _tlg_ArgInt(int8_t, value, _tlgHex, 0, _tlg_NDT(TraceLoggingHexInt8, value, __VA_ARGS__))
-#define TraceLoggingHexUInt8(value, ...) _tlg_ArgInt(uint8_t, value, _tlgHex, 0, _tlg_NDT(TraceLoggingHexUInt8, value, __VA_ARGS__))
-#define TraceLoggingHexInt16(value, ...) _tlg_ArgInt(int16_t, value, _tlgHex, 0, _tlg_NDT(TraceLoggingHexInt16, value, __VA_ARGS__))
-#define TraceLoggingHexUInt16(value, ...) _tlg_ArgInt(uint16_t, value, _tlgHex, 0, _tlg_NDT(TraceLoggingHexUInt16, value, __VA_ARGS__))
-#define TraceLoggingHexInt32(value, ...) _tlg_ArgInt(int32_t, value, _tlgHex, 0, _tlg_NDT(TraceLoggingHexInt32, value, __VA_ARGS__))
-#define TraceLoggingHexUInt32(value, ...) _tlg_ArgInt(uint32_t, value, _tlgHex, 0, _tlg_NDT(TraceLoggingHexUInt32, value, __VA_ARGS__))
-#define TraceLoggingHexLong(value, ...) _tlg_ArgInt(long, value, _tlgHex, 0, _tlg_NDT(TraceLoggingHexLong, value, __VA_ARGS__))
-#define TraceLoggingHexULong(value, ...) _tlg_ArgInt(unsigned long, value, _tlgHex, 0, _tlg_NDT(TraceLoggingHexULong, value, __VA_ARGS__))
-#define TraceLoggingHexInt64(value, ...) _tlg_ArgInt(int64_t, value, _tlgHex, 0, _tlg_NDT(TraceLoggingHexInt64, value, __VA_ARGS__))
-#define TraceLoggingHexUInt64(value, ...) _tlg_ArgInt(uint64_t, value, _tlgHex, 0, _tlg_NDT(TraceLoggingHexUInt64, value, __VA_ARGS__))
-#define TraceLoggingIntPtr(value, ...) _tlg_ArgInt(intptr_t, value, _tlgDecimal, 1, _tlg_NDT(TraceLoggingIntPtr, value, __VA_ARGS__))
-#define TraceLoggingUIntPtr(value, ...) _tlg_ArgInt(uintptr_t, value, _tlgDecimal, 0, _tlg_NDT(TraceLoggingUIntPtr, value, __VA_ARGS__))
-#define TraceLoggingFloat32(value, ...) _tlg_ArgFloat(float, value, _tlg_NDT(TraceLoggingFloat32, value, __VA_ARGS__))
-#define TraceLoggingFloat64(value, ...) _tlg_ArgFloat(double, value, _tlg_NDT(TraceLoggingFloat64, value, __VA_ARGS__))
-#define TraceLoggingBool(value, ...) _tlg_ArgEnum(int32_t, value, _tlgDecimal, 1, _tlg_NDT(TraceLoggingBool, value, __VA_ARGS__), lttngh_BoolEnumDesc)
-#define TraceLoggingBoolean(value, ...) _tlg_ArgEnum(uint8_t, value, _tlgDecimal, 0, _tlg_NDT(TraceLoggingBoolean, value, __VA_ARGS__), lttngh_BoolEnumDesc)
-#define TraceLoggingChar(value, ...) _tlg_ArgChar8(char, value, _tlg_NDT(TraceLoggingChar, value, __VA_ARGS__))
-#define TraceLoggingWChar(value, ...) _tlg_ArgCharW(wchar_t, value, _tlg_NDT(TraceLoggingWChar, value, __VA_ARGS__))
-#define TraceLoggingChar16(value, ...) _tlg_ArgCharNN(char16_t, value, 16, _tlg_NDT(TraceLoggingChar16, value, __VA_ARGS__))
-#define TraceLoggingChar32(value, ...) _tlg_ArgCharNN(char32_t, value, 32, _tlg_NDT(TraceLoggingChar32, value, __VA_ARGS__))
-#define TraceLoggingPointer(value, ...) _tlg_ArgInt(void const *, value, _tlgHex, 0, _tlg_NDT(TraceLoggingPointer, value, __VA_ARGS__))
-#define TraceLoggingCodePointer(value, ...) _tlg_ArgInt(void const *, value, _tlgHex, 0, _tlg_NDT(TraceLoggingCodePointer, value, __VA_ARGS__))
-#define TraceLoggingPid(value, ...) _tlg_ArgInt(uint32_t, value, _tlgDecimal, 0, _tlg_NDT(TraceLoggingPid, value, __VA_ARGS__))
-#define TraceLoggingTid(value, ...) _tlg_ArgInt(uint32_t, value, _tlgDecimal, 0, _tlg_NDT(TraceLoggingTid, value, __VA_ARGS__))
-#define TraceLoggingPort(value, ...) _tlg_ArgInt(uint16_t, value, _tlgDecimalBE, 0, _tlg_NDT(TraceLoggingPort, value, __VA_ARGS__))
-#define TraceLoggingWinError(value, ...) _tlg_ArgInt(uint32_t, value, _tlgDecimal, 0, _tlg_NDT(TraceLoggingWinError, value, __VA_ARGS__))
-#define TraceLoggingNTStatus(value, ...) _tlg_ArgInt(int32_t, value, _tlgHex, 0, _tlg_NDT(TraceLoggingNTStatus, value, __VA_ARGS__))
-#define TraceLoggingHResult(value, ...) _tlg_ArgInt(int32_t, value, _tlgHex, 0, _tlg_NDT(TraceLoggingHResult, value, __VA_ARGS__))
+#define TraceLoggingInt8(value, ...)        _tlg_ArgScalar(int8_t,      value,  (lttngh_TypeInt8),     Signed,   _tlg_NDT(TraceLoggingInt8, value, __VA_ARGS__))
+#define TraceLoggingUInt8(value, ...)       _tlg_ArgScalar(uint8_t,     value,  (lttngh_TypeUInt8),    Unsigned, _tlg_NDT(TraceLoggingUInt8, value, __VA_ARGS__))
+#define TraceLoggingInt16(value, ...)       _tlg_ArgScalar(int16_t,     value,  (lttngh_TypeInt16),    Signed,   _tlg_NDT(TraceLoggingInt16, value, __VA_ARGS__))
+#define TraceLoggingUInt16(value, ...)      _tlg_ArgScalar(uint16_t,    value,  (lttngh_TypeUInt16),   Unsigned, _tlg_NDT(TraceLoggingUInt16, value, __VA_ARGS__))
+#define TraceLoggingInt32(value, ...)       _tlg_ArgScalar(int32_t,     value,  (lttngh_TypeInt32),    Signed,   _tlg_NDT(TraceLoggingInt32, value, __VA_ARGS__))
+#define TraceLoggingUInt32(value, ...)      _tlg_ArgScalar(uint32_t,    value,  (lttngh_TypeUInt32),   Unsigned, _tlg_NDT(TraceLoggingUInt32, value, __VA_ARGS__))
+#define TraceLoggingLong(value, ...)        _tlg_ArgScalar(signed long, value,  (lttngh_TypeLong),     Signed,   _tlg_NDT(TraceLoggingLong, value, __VA_ARGS__))
+#define TraceLoggingULong(value, ...)       _tlg_ArgScalar(unsigned long,value, (lttngh_TypeULong),    Unsigned, _tlg_NDT(TraceLoggingULong, value, __VA_ARGS__))
+#define TraceLoggingInt64(value, ...)       _tlg_ArgScalar(int64_t,     value,  (lttngh_TypeInt64),    Signed,   _tlg_NDT(TraceLoggingInt64, value, __VA_ARGS__))
+#define TraceLoggingUInt64(value, ...)      _tlg_ArgScalar(uint64_t,    value,  (lttngh_TypeUInt64),   Unsigned, _tlg_NDT(TraceLoggingUInt64, value, __VA_ARGS__))
+#define TraceLoggingHexInt8(value, ...)     _tlg_ArgScalar(int8_t,      value,  (lttngh_TypeHexInt8),  Unsigned, _tlg_NDT(TraceLoggingHexInt8, value, __VA_ARGS__))
+#define TraceLoggingHexUInt8(value, ...)    _tlg_ArgScalar(uint8_t,     value,  (lttngh_TypeHexInt8),  Unsigned, _tlg_NDT(TraceLoggingHexUInt8, value, __VA_ARGS__))
+#define TraceLoggingHexInt16(value, ...)    _tlg_ArgScalar(int16_t,     value,  (lttngh_TypeHexInt16), Unsigned, _tlg_NDT(TraceLoggingHexInt16, value, __VA_ARGS__))
+#define TraceLoggingHexUInt16(value, ...)   _tlg_ArgScalar(uint16_t,    value,  (lttngh_TypeHexInt16), Unsigned, _tlg_NDT(TraceLoggingHexUInt16, value, __VA_ARGS__))
+#define TraceLoggingHexInt32(value, ...)    _tlg_ArgScalar(int32_t,     value,  (lttngh_TypeHexInt32), Unsigned, _tlg_NDT(TraceLoggingHexInt32, value, __VA_ARGS__))
+#define TraceLoggingHexUInt32(value, ...)   _tlg_ArgScalar(uint32_t,    value,  (lttngh_TypeHexInt32), Unsigned, _tlg_NDT(TraceLoggingHexUInt32, value, __VA_ARGS__))
+#define TraceLoggingHexLong(value, ...)     _tlg_ArgScalar(signed long, value,  (lttngh_TypeHexLong),  Unsigned, _tlg_NDT(TraceLoggingHexLong, value, __VA_ARGS__))
+#define TraceLoggingHexULong(value, ...)    _tlg_ArgScalar(unsigned long, value,(lttngh_TypeHexLong),  Unsigned, _tlg_NDT(TraceLoggingHexULong, value, __VA_ARGS__))
+#define TraceLoggingHexInt64(value, ...)    _tlg_ArgScalar(int64_t,     value,  (lttngh_TypeHexInt64), Unsigned, _tlg_NDT(TraceLoggingHexInt64, value, __VA_ARGS__))
+#define TraceLoggingHexUInt64(value, ...)   _tlg_ArgScalar(uint64_t,    value,  (lttngh_TypeHexInt64), Unsigned, _tlg_NDT(TraceLoggingHexUInt64, value, __VA_ARGS__))
+#define TraceLoggingIntPtr(value, ...)      _tlg_ArgScalar(intptr_t,    value,  (lttngh_TypeHexIntPtr),Signed,   _tlg_NDT(TraceLoggingIntPtr, value, __VA_ARGS__))
+#define TraceLoggingUIntPtr(value, ...)     _tlg_ArgScalar(uintptr_t,   value,  (lttngh_TypeHexIntPtr),Unsigned, _tlg_NDT(TraceLoggingUIntPtr, value, __VA_ARGS__))
+#define TraceLoggingFloat32(value, ...)     _tlg_ArgScalar(float,       value,  (lttngh_TypeFloat32),  Float,    _tlg_NDT(TraceLoggingFloat32, value, __VA_ARGS__))
+#define TraceLoggingFloat64(value, ...)     _tlg_ArgScalar(double,      value,  (lttngh_TypeFloat64),  Float,    _tlg_NDT(TraceLoggingFloat64, value, __VA_ARGS__))
+#define TraceLoggingBool(value, ...)        _tlg_ArgScalar(int32_t,     value,  (lttngh_TypeBool32),   Signed,   _tlg_NDT(TraceLoggingBool, value, __VA_ARGS__))
+#define TraceLoggingBoolean(value, ...)     _tlg_ArgScalar(uint8_t,     value,  (lttngh_TypeBool8),    Unsigned, _tlg_NDT(TraceLoggingBoolean, value, __VA_ARGS__))
+#define TraceLoggingChar(value, ...)        _tlg_ArgChar8( char,        value,                                   _tlg_NDT(TraceLoggingChar, value, __VA_ARGS__))
+#define TraceLoggingWChar(value, ...)       _tlg_ArgCharW( wchar_t,     value,                                   _tlg_NDT(TraceLoggingWChar, value, __VA_ARGS__))
+#define TraceLoggingChar16(value, ...)      _tlg_ArgCharNN(char16_t,    value, 16,                               _tlg_NDT(TraceLoggingChar16, value, __VA_ARGS__))
+#define TraceLoggingChar32(value, ...)      _tlg_ArgCharNN(char32_t,    value, 32,                               _tlg_NDT(TraceLoggingChar32, value, __VA_ARGS__))
+#define TraceLoggingPointer(value, ...)     _tlg_ArgScalar(void const*, value,  (lttngh_TypeHexIntPtr),Unsigned, _tlg_NDT(TraceLoggingPointer, value, __VA_ARGS__))
+#define TraceLoggingCodePointer(value, ...) _tlg_ArgScalar(void const*, value,  (lttngh_TypeHexIntPtr),Unsigned, _tlg_NDT(TraceLoggingCodePointer, value, __VA_ARGS__))
+#define TraceLoggingPid(value, ...)         _tlg_ArgScalar(uint32_t,    value,  (lttngh_TypeUInt32),   Unsigned, _tlg_NDT(TraceLoggingPid, value, __VA_ARGS__))
+#define TraceLoggingTid(value, ...)         _tlg_ArgScalar(uint32_t,    value,  (lttngh_TypeUInt32),   Unsigned, _tlg_NDT(TraceLoggingTid, value, __VA_ARGS__))
+#define TraceLoggingPort(value, ...)        _tlg_ArgScalar(uint16_t,    value,  (lttngh_TypeUInt16BE), Unsigned, _tlg_NDT(TraceLoggingPort, value, __VA_ARGS__))
+#define TraceLoggingWinError(value, ...)    _tlg_ArgScalar(uint32_t,    value,  (lttngh_TypeUInt32),   Unsigned, _tlg_NDT(TraceLoggingWinError, value, __VA_ARGS__))
+#define TraceLoggingNTStatus(value, ...)    _tlg_ArgScalar(int32_t,     value,  (lttngh_TypeHexInt32), Unsigned, _tlg_NDT(TraceLoggingNTStatus, value, __VA_ARGS__))
+#define TraceLoggingHResult(value, ...)     _tlg_ArgScalar(int32_t,     value,  (lttngh_TypeHexInt32), Unsigned, _tlg_NDT(TraceLoggingHResult, value, __VA_ARGS__))
 
 /*
 Wrapper macros for event fields with complex scalar values.
@@ -796,7 +779,7 @@ LTTNG-specific:
 - Violations of these rules cannot be detected by TraceLoggingProvider.h, but
   will likely cause problems when you try to decode the trace.
 - Be especially careful with automatically-generated field names, as they
-  often contain spaces other problematic symbols.
+  often contain spaces or other problematic symbols.
 
 If provided, the description parameter must be a string literal.
 (Field description is ignored for LTTNG.)
@@ -814,7 +797,7 @@ LTTNG-specific:
   In C++, value can be an rvalue.
 - GUID will be logged as an array of 16 hexadecimal bytes.
 - SYSTEMTIME will be logged as an array of 8 decimal ushorts (16 bytes total).
-- FILETIME will be logged as an array of 1 decimal uint64.
+- FILETIME will be logged as an array of 1 decimal uint64 (8 bytes total).
 
 Examples:
 - TraceLoggingGuid(val1)                      // field name = "val1", description = unset,  tags = 0.
@@ -822,11 +805,11 @@ Examples:
 - TraceLoggingGuid(val1, "name", "desc")      // field name = "name", description = "desc", tags = 0.
 - TraceLoggingGuid(val1, "name", "desc", 0x4) // field name = "name", description = "desc", tags = 0x4.
 */
-#define TraceLoggingGuid(value, ...) _tlg_ArgIntArrayByRef(uint8_t, value, 16, _tlgHex, 0, _tlg_NDT(TraceLoggingGuid, value, __VA_ARGS__))
-#define TraceLoggingSystemTime(value, ...) _tlg_ArgIntArrayByRef(uint16_t, value, 8, _tlgDecimal, 0, _tlg_NDT(TraceLoggingSystemTime, value, __VA_ARGS__))
-#define TraceLoggingSystemTimeUtc(value, ...) _tlg_ArgIntArrayByRef(uint16_t, value, 8, _tlgDecimal, 0, _tlg_NDT(TraceLoggingSystemTimeUtc, value, __VA_ARGS__))
-#define TraceLoggingFileTime(value, ...) _tlg_ArgIntArrayByRef(uint64_t, value, 1, _tlgDecimal, 0, _tlg_NDT(TraceLoggingFileTime, value, __VA_ARGS__))
-#define TraceLoggingFileTimeUtc(value, ...) _tlg_ArgIntArrayByRef(uint64_t, value, 1, _tlgDecimal, 0, _tlg_NDT(TraceLoggingFileTimeUtc, value, __VA_ARGS__))
+#define TraceLoggingGuid(value, ...)          _tlg_ArgScalarByRef(uint8_t,  value, 16, (lttngh_TypeGuid),      _tlg_NDT(TraceLoggingGuid, value, __VA_ARGS__))
+#define TraceLoggingSystemTime(value, ...)    _tlg_ArgScalarByRef(uint16_t, value, 8,  (lttngh_TypeSystemTime),_tlg_NDT(TraceLoggingSystemTime, value, __VA_ARGS__))
+#define TraceLoggingSystemTimeUtc(value, ...) _tlg_ArgScalarByRef(uint16_t, value, 8,  (lttngh_TypeSystemTime),_tlg_NDT(TraceLoggingSystemTimeUtc, value, __VA_ARGS__))
+#define TraceLoggingFileTime(value, ...)      _tlg_ArgScalarByRef(uint64_t, value, 1,  (lttngh_TypeFileTime),  _tlg_NDT(TraceLoggingFileTime, value, __VA_ARGS__))
+#define TraceLoggingFileTimeUtc(value, ...)   _tlg_ArgScalarByRef(uint64_t, value, 1,  (lttngh_TypeFileTime),  _tlg_NDT(TraceLoggingFileTimeUtc, value, __VA_ARGS__))
 
 /*
 Wrapper macros for event fields with string values.
@@ -862,7 +845,7 @@ LTTNG-specific:
 - Violations of these rules cannot be detected by TraceLoggingProvider.h, but
   will likely cause problems when you try to decode the trace.
 - Be especially careful with automatically-generated field names, as they
-  often contain spaces other problematic symbols.
+  often contain spaces or other problematic symbols.
 
 If provided, the description parameter must be a string literal.
 (Field description is ignored for LTTNG.)
@@ -881,13 +864,13 @@ Examples:
 - TraceLoggingString(psz1, "name", "desc")      // field name = "name", description = "desc", tags = 0.
 - TraceLoggingString(psz1, "name", "desc", 0x4) // field name = "name", description = "desc", tags = 0x4.
 */
-#define TraceLoggingString(pszValue, ...) _tlg_ArgString8(char, pszValue, _tlg_NDT(TraceLoggingString, pszValue, __VA_ARGS__))
-#define TraceLoggingUtf8String(pszValue, ...) TraceLoggingString(pszValue, __VA_ARGS__)
+#define TraceLoggingString(pszValue, ...)     _tlg_ArgString8(char, pszValue, _tlg_NDT(TraceLoggingString, pszValue, __VA_ARGS__))
+#define TraceLoggingUtf8String(pszValue, ...) _tlg_ArgString8(char, pszValue, _tlg_NDT(TraceLoggingUtf8String, pszValue, __VA_ARGS__))
 #define TraceLoggingWideString(pszValue, ...) _tlg_ArgStringW(wchar_t, pszValue, _tlg_NDT(TraceLoggingWideString, pszValue, __VA_ARGS__))
 #define TraceLoggingString16(pszValue, ...) _tlg_ArgStringNN(char16_t, pszValue, 16, _tlg_NDT(TraceLoggingString16, pszValue, __VA_ARGS__))
 #define TraceLoggingString32(pszValue, ...) _tlg_ArgStringNN(char32_t, pszValue, 32, _tlg_NDT(TraceLoggingString32, pszValue, __VA_ARGS__))
-#define TraceLoggingCountedString(pchValue, cchValue, ...) _tlg_ArgCountedString8(char, pchValue, cchValue, _tlg_NDT(TraceLoggingCountedString, pchValue, __VA_ARGS__))
-#define TraceLoggingCountedUtf8String(pchValue, cchValue, ...) TraceLoggingCountedString(pchValue, cchValue, __VA_ARGS__)
+#define TraceLoggingCountedString(pchValue, cchValue, ...)     _tlg_ArgCountedString8(char, pchValue, cchValue, _tlg_NDT(TraceLoggingCountedString, pchValue, __VA_ARGS__))
+#define TraceLoggingCountedUtf8String(pchValue, cchValue, ...) _tlg_ArgCountedString8(char, pchValue, cchValue, _tlg_NDT(TraceLoggingCountedUtf8String, pchValue, __VA_ARGS__))
 #define TraceLoggingCountedWideString(pchValue, cchValue, ...) _tlg_ArgCountedStringW(wchar_t, pchValue, cchValue, _tlg_NDT(TraceLoggingCountedWideString, pchValue, __VA_ARGS__))
 #define TraceLoggingCountedString16(pchValue, cchValue, ...) _tlg_ArgCountedStringNN(char16_t, pchValue, cchValue, 16, _tlg_NDT(TraceLoggingCountedString16, pchValue, __VA_ARGS__))
 #define TraceLoggingCountedString32(pchValue, cchValue, ...) _tlg_ArgCountedStringNN(char32_t, pchValue, cchValue, 32, _tlg_NDT(TraceLoggingCountedString32, pchValue, __VA_ARGS__))
@@ -915,7 +898,7 @@ LTTNG-specific:
 - Violations of these rules cannot be detected by TraceLoggingProvider.h, but
   will likely cause problems when you try to decode the trace.
 - Be especially careful with automatically-generated field names, as they
-  often contain spaces other problematic symbols.
+  often contain spaces or other problematic symbols.
 
 If provided, the description parameter must be a string literal.
 (Field description is ignored for LTTNG.)
@@ -953,7 +936,7 @@ LTTNG-specific:
 - Violations of these rules cannot be detected by TraceLoggingProvider.h, but
   will likely cause problems when you try to decode the trace.
 - Be especially careful with automatically-generated field names, as they
-  often contain spaces other problematic symbols.
+  often contain spaces or other problematic symbols.
 
 If provided, the description parameter must be a string literal.
 (Field description is ignored for LTTNG.)
@@ -994,7 +977,7 @@ LTTNG-specific:
 - Violations of these rules cannot be detected by TraceLoggingProvider.h, but
   will likely cause problems when you try to decode the trace.
 - Be especially careful with automatically-generated field names, as they
-  often contain spaces other problematic symbols.
+  often contain spaces or other problematic symbols.
 
 If provided, the description parameter must be a string literal.
 (Field description is ignored for LTTNG.)
@@ -1040,7 +1023,7 @@ LTTNG-specific:
 - Violations of these rules cannot be detected by TraceLoggingProvider.h, but
   will likely cause problems when you try to decode the trace.
 - Be especially careful with automatically-generated field names, as they
-  often contain spaces other problematic symbols.
+  often contain spaces or other problematic symbols.
 
 If provided, the description parameter must be a string literal.
 (Field description is ignored for LTTNG.)
@@ -1077,7 +1060,7 @@ LTTNG-specific:
 - Violations of these rules cannot be detected by TraceLoggingProvider.h, but
   will likely cause problems when you try to decode the trace.
 - Be especially careful with automatically-generated field names, as they
-  often contain spaces other problematic symbols.
+  often contain spaces or other problematic symbols.
 
 If provided, the description parameter must be a string literal.
 (Field description is ignored for LTTNG.)
@@ -1091,45 +1074,47 @@ Examples:
 - TraceLoggingUInt8FixedArray(pbX1, 32, "name", "desc")      // field name = "name", description = "desc", tags = 0.
 - TraceLoggingUInt8FixedArray(pbX1, 32, "name", "desc", 0x4) // field name = "name", description = "desc", tags = 0x4.
 */
-#define TraceLoggingInt8FixedArray(pValues, cValues, ...) _tlg_ArgIntFixedArray(int8_t, pValues, cValues, _tlgDecimal, 1, _tlg_NDT(TraceLoggingInt8FixedArray, pValues, __VA_ARGS__))
-#define TraceLoggingUInt8FixedArray(pValues, cValues, ...) _tlg_ArgIntFixedArray(uint8_t, pValues, cValues, _tlgDecimal, 0, _tlg_NDT(TraceLoggingUInt8FixedArray, pValues, __VA_ARGS__))
-#define TraceLoggingInt16FixedArray(pValues, cValues, ...) _tlg_ArgIntFixedArray(int16_t, pValues, cValues, _tlgDecimal, 1, _tlg_NDT(TraceLoggingInt16FixedArray, pValues, __VA_ARGS__))
-#define TraceLoggingUInt16FixedArray(pValues, cValues, ...) _tlg_ArgIntFixedArray(uint16_t, pValues, cValues, _tlgDecimal, 0, _tlg_NDT(TraceLoggingUInt16FixedArray, pValues, __VA_ARGS__))
-#define TraceLoggingInt32FixedArray(pValues, cValues, ...) _tlg_ArgIntFixedArray(int32_t, pValues, cValues, _tlgDecimal, 1, _tlg_NDT(TraceLoggingInt32FixedArray, pValues, __VA_ARGS__))
-#define TraceLoggingUInt32FixedArray(pValues, cValues, ...) _tlg_ArgIntFixedArray(uint32_t, pValues, cValues, _tlgDecimal, 0, _tlg_NDT(TraceLoggingUInt32FixedArray, pValues, __VA_ARGS__))
-#define TraceLoggingLongFixedArray(pValues, cValues, ...) _tlg_ArgIntFixedArray(long, pValues, cValues, _tlgDecimal, 1, _tlg_NDT(TraceLoggingLongFixedArray, pValues, __VA_ARGS__))
-#define TraceLoggingULongFixedArray(pValues, cValues, ...) _tlg_ArgIntFixedArray(unsigned long, pValues, cValues, _tlgDecimal, 0, _tlg_NDT(TraceLoggingULongFixedArray, pValues, __VA_ARGS__))
-#define TraceLoggingInt64FixedArray(pValues, cValues, ...) _tlg_ArgIntFixedArray(int64_t, pValues, cValues, _tlgDecimal, 1, _tlg_NDT(TraceLoggingInt64FixedArray, pValues, __VA_ARGS__))
-#define TraceLoggingUInt64FixedArray(pValues, cValues, ...) _tlg_ArgIntFixedArray(uint64_t, pValues, cValues, _tlgDecimal, 0, _tlg_NDT(TraceLoggingUInt64FixedArray, pValues, __VA_ARGS__))
-#define TraceLoggingHexInt8FixedArray(pValues, cValues, ...) _tlg_ArgIntFixedArray(int8_t, pValues, cValues, _tlgHex, 0, _tlg_NDT(TraceLoggingHexInt8FixedArray, pValues, __VA_ARGS__))
-#define TraceLoggingHexUInt8FixedArray(pValues, cValues, ...) _tlg_ArgIntFixedArray(uint8_t, pValues, cValues, _tlgHex, 0, _tlg_NDT(TraceLoggingHexUInt8FixedArray, pValues, __VA_ARGS__))
-#define TraceLoggingHexInt16FixedArray(pValues, cValues, ...) _tlg_ArgIntFixedArray(int16_t, pValues, cValues, _tlgHex, 0, _tlg_NDT(TraceLoggingHexInt16FixedArray, pValues, __VA_ARGS__))
-#define TraceLoggingHexUInt16FixedArray(pValues, cValues, ...) _tlg_ArgIntFixedArray(uint16_t, pValues, cValues, _tlgHex, 0, _tlg_NDT(TraceLoggingHexUInt16FixedArray, pValues, __VA_ARGS__))
-#define TraceLoggingHexInt32FixedArray(pValues, cValues, ...) _tlg_ArgIntFixedArray(int32_t, pValues, cValues, _tlgHex, 0, _tlg_NDT(TraceLoggingHexInt32FixedArray, pValues, __VA_ARGS__))
-#define TraceLoggingHexUInt32FixedArray(pValues, cValues, ...) _tlg_ArgIntFixedArray(uint32_t, pValues, cValues, _tlgHex, 0, _tlg_NDT(TraceLoggingHexUInt32FixedArray, pValues, __VA_ARGS__))
-#define TraceLoggingHexLongFixedArray(pValues, cValues, ...) _tlg_ArgIntFixedArray(long, pValues, cValues, _tlgHex, 0, _tlg_NDT(TraceLoggingHexLongFixedArray, pValues, __VA_ARGS__))
-#define TraceLoggingHexULongFixedArray(pValues, cValues, ...) _tlg_ArgIntFixedArray(unsigned long, pValues, cValues, _tlgHex, 0, _tlg_NDT(TraceLoggingHexULongFixedArray, pValues, __VA_ARGS__))
-#define TraceLoggingHexInt64FixedArray(pValues, cValues, ...) _tlg_ArgIntFixedArray(int64_t, pValues, cValues, _tlgHex, 0, _tlg_NDT(TraceLoggingHexInt64FixedArray, pValues, __VA_ARGS__))
-#define TraceLoggingHexUInt64FixedArray(pValues, cValues, ...) _tlg_ArgIntFixedArray(uint64_t, pValues, cValues, _tlgHex, 0, _tlg_NDT(TraceLoggingHexUInt64FixedArray, pValues, __VA_ARGS__))
-#define TraceLoggingIntPtrFixedArray(pValues, cValues, ...) _tlg_ArgIntFixedArray(intptr_t, pValues, cValues, _tlgDecimal, 1, _tlg_NDT(TraceLoggingIntPtrFixedArray, pValues, __VA_ARGS__))
-#define TraceLoggingUIntPtrFixedArray(pValues, cValues, ...) _tlg_ArgIntFixedArray(uintptr_t, pValues, cValues, _tlgDecimal, 0, _tlg_NDT(TraceLoggingUIntPtrFixedArray, pValues, __VA_ARGS__))
-#define TraceLoggingBoolFixedArray(pValues, cValues, ...) _tlg_ArgIntFixedArray(int32_t, pValues, cValues, _tlgDecimal, 1, _tlg_NDT(TraceLoggingBoolFixedArray, pValues, __VA_ARGS__))
-#define TraceLoggingBooleanFixedArray(pValues, cValues, ...) _tlg_ArgIntFixedArray(uint8_t, pValues, cValues, _tlgDecimal, 0, _tlg_NDT(TraceLoggingBooleanFixedArray, pValues, __VA_ARGS__))
-#define TraceLoggingCharFixedArray(pValues, cValues, ...) _tlg_ArgCountedString8(char, pValues, cValues, _tlg_NDT(TraceLoggingCharFixedArray, pValues, __VA_ARGS__))
-#define TraceLoggingWCharFixedArray(pValues, cValues, ...) _tlg_ArgCountedStringW(wchar_t, pValues, cValues, _tlg_NDT(TraceLoggingWCharFixedArray, pValues, __VA_ARGS__))
+#define TraceLoggingInt8FixedArray(pValues, cValues, ...)       _tlg_ArgFixedArray(int8_t,      pValues, cValues, (lttngh_TypeInt8), _tlg_NDT(TraceLoggingInt8FixedArray, pValues, __VA_ARGS__))
+#define TraceLoggingUInt8FixedArray(pValues, cValues, ...)      _tlg_ArgFixedArray(uint8_t,     pValues, cValues, (lttngh_TypeUInt8), _tlg_NDT(TraceLoggingUInt8FixedArray, pValues, __VA_ARGS__))
+#define TraceLoggingInt16FixedArray(pValues, cValues, ...)      _tlg_ArgFixedArray(int16_t,     pValues, cValues, (lttngh_TypeInt16), _tlg_NDT(TraceLoggingInt16FixedArray, pValues, __VA_ARGS__))
+#define TraceLoggingUInt16FixedArray(pValues, cValues, ...)     _tlg_ArgFixedArray(uint16_t,    pValues, cValues, (lttngh_TypeUInt16), _tlg_NDT(TraceLoggingUInt16FixedArray, pValues, __VA_ARGS__))
+#define TraceLoggingInt32FixedArray(pValues, cValues, ...)      _tlg_ArgFixedArray(int32_t,     pValues, cValues, (lttngh_TypeInt32), _tlg_NDT(TraceLoggingInt32FixedArray, pValues, __VA_ARGS__))
+#define TraceLoggingUInt32FixedArray(pValues, cValues, ...)     _tlg_ArgFixedArray(uint32_t,    pValues, cValues, (lttngh_TypeUInt32), _tlg_NDT(TraceLoggingUInt32FixedArray, pValues, __VA_ARGS__))
+#define TraceLoggingLongFixedArray(pValues, cValues, ...)       _tlg_ArgFixedArray(signed long, pValues, cValues, (lttngh_TypeLong), _tlg_NDT(TraceLoggingLongFixedArray, pValues, __VA_ARGS__))
+#define TraceLoggingULongFixedArray(pValues, cValues, ...)      _tlg_ArgFixedArray(unsigned long,pValues,cValues, (lttngh_TypeULong), _tlg_NDT(TraceLoggingULongFixedArray, pValues, __VA_ARGS__))
+#define TraceLoggingInt64FixedArray(pValues, cValues, ...)      _tlg_ArgFixedArray(int64_t,     pValues, cValues, (lttngh_TypeInt64), _tlg_NDT(TraceLoggingInt64FixedArray, pValues, __VA_ARGS__))
+#define TraceLoggingUInt64FixedArray(pValues, cValues, ...)     _tlg_ArgFixedArray(uint64_t,    pValues, cValues, (lttngh_TypeUInt64), _tlg_NDT(TraceLoggingUInt64FixedArray, pValues, __VA_ARGS__))
+#define TraceLoggingHexInt8FixedArray(pValues, cValues, ...)    _tlg_ArgFixedArray(int8_t,      pValues, cValues, (lttngh_TypeHexInt8), _tlg_NDT(TraceLoggingHexInt8FixedArray, pValues, __VA_ARGS__))
+#define TraceLoggingHexUInt8FixedArray(pValues, cValues, ...)   _tlg_ArgFixedArray(uint8_t,     pValues, cValues, (lttngh_TypeHexInt8), _tlg_NDT(TraceLoggingHexUInt8FixedArray, pValues, __VA_ARGS__))
+#define TraceLoggingHexInt16FixedArray(pValues, cValues, ...)   _tlg_ArgFixedArray(int16_t,     pValues, cValues, (lttngh_TypeHexInt16), _tlg_NDT(TraceLoggingHexInt16FixedArray, pValues, __VA_ARGS__))
+#define TraceLoggingHexUInt16FixedArray(pValues, cValues, ...)  _tlg_ArgFixedArray(uint16_t,    pValues, cValues, (lttngh_TypeHexInt16), _tlg_NDT(TraceLoggingHexUInt16FixedArray, pValues, __VA_ARGS__))
+#define TraceLoggingHexInt32FixedArray(pValues, cValues, ...)   _tlg_ArgFixedArray(int32_t,     pValues, cValues, (lttngh_TypeHexInt32), _tlg_NDT(TraceLoggingHexInt32FixedArray, pValues, __VA_ARGS__))
+#define TraceLoggingHexUInt32FixedArray(pValues, cValues, ...)  _tlg_ArgFixedArray(uint32_t,    pValues, cValues, (lttngh_TypeHexInt32), _tlg_NDT(TraceLoggingHexUInt32FixedArray, pValues, __VA_ARGS__))
+#define TraceLoggingHexLongFixedArray(pValues, cValues, ...)    _tlg_ArgFixedArray(signed long, pValues, cValues, (lttngh_TypeHexLong), _tlg_NDT(TraceLoggingHexLongFixedArray, pValues, __VA_ARGS__))
+#define TraceLoggingHexULongFixedArray(pValues, cValues, ...)   _tlg_ArgFixedArray(unsigned long,pValues,cValues, (lttngh_TypeHexLong), _tlg_NDT(TraceLoggingHexULongFixedArray, pValues, __VA_ARGS__))
+#define TraceLoggingHexInt64FixedArray(pValues, cValues, ...)   _tlg_ArgFixedArray(int64_t,     pValues, cValues, (lttngh_TypeHexInt64), _tlg_NDT(TraceLoggingHexInt64FixedArray, pValues, __VA_ARGS__))
+#define TraceLoggingHexUInt64FixedArray(pValues, cValues, ...)  _tlg_ArgFixedArray(uint64_t,    pValues, cValues, (lttngh_TypeHexInt64), _tlg_NDT(TraceLoggingHexUInt64FixedArray, pValues, __VA_ARGS__))
+#define TraceLoggingIntPtrFixedArray(pValues, cValues, ...)     _tlg_ArgFixedArray(intptr_t,    pValues, cValues, (lttngh_TypeHexIntPtr), _tlg_NDT(TraceLoggingIntPtrFixedArray, pValues, __VA_ARGS__))
+#define TraceLoggingUIntPtrFixedArray(pValues, cValues, ...)    _tlg_ArgFixedArray(uintptr_t,   pValues, cValues, (lttngh_TypeHexIntPtr), _tlg_NDT(TraceLoggingUIntPtrFixedArray, pValues, __VA_ARGS__))
+#define TraceLoggingBoolFixedArray(pValues, cValues, ...)       _tlg_ArgFixedArray(int32_t,     pValues, cValues, (lttngh_TypeBool32ForArray), _tlg_NDT(TraceLoggingBoolFixedArray, pValues, __VA_ARGS__))
+#define TraceLoggingBooleanFixedArray(pValues, cValues, ...)    _tlg_ArgFixedArray(uint8_t,     pValues, cValues, (lttngh_TypeBool8ForArray), _tlg_NDT(TraceLoggingBooleanFixedArray, pValues, __VA_ARGS__))
+
+#define TraceLoggingCharFixedArray(pValues, cValues, ...)   _tlg_ArgCountedString8( char,     pValues, cValues, _tlg_NDT(TraceLoggingCharFixedArray, pValues, __VA_ARGS__))
+#define TraceLoggingWCharFixedArray(pValues, cValues, ...)  _tlg_ArgCountedStringW( wchar_t,  pValues, cValues, _tlg_NDT(TraceLoggingWCharFixedArray, pValues, __VA_ARGS__))
 #define TraceLoggingChar16FixedArray(pValues, cValues, ...) _tlg_ArgCountedStringNN(char16_t, pValues, cValues, 16, _tlg_NDT(TraceLoggingChar16FixedArray, pValues, __VA_ARGS__))
 #define TraceLoggingChar32FixedArray(pValues, cValues, ...) _tlg_ArgCountedStringNN(char32_t, pValues, cValues, 32, _tlg_NDT(TraceLoggingChar32FixedArray, pValues, __VA_ARGS__))
-#define TraceLoggingPointerFixedArray(pValues, cValues, ...) _tlg_ArgIntFixedArray(void const *, pValues, cValues, _tlgHex, 0, _tlg_NDT(TraceLoggingPointerFixedArray, pValues, __VA_ARGS__))
-#define TraceLoggingCodePointerFixedArray(pValues, cValues, ...) _tlg_ArgIntFixedArray(void const *, pValues, cValues, _tlgHex, 0, _tlg_NDT(TraceLoggingCodePointerFixedArray, pValues, __VA_ARGS__))
-#define TraceLoggingGuidFixedArray(pValues, cValues, ...) _tlg_ArgIntFixedArray(uint8_t, (uint8_t const *)(pValues), (cValues)*16u, _tlgDecimal, 0, _tlg_NDT(TraceLoggingGuidFixedArray, pValues, __VA_ARGS__))
-#define TraceLoggingFileTimeFixedArray(pValues, cValues, ...) _tlg_ArgIntFixedArray(uint64_t, (uint64_t const *)(pValues), cValues, _tlgHex, 0, _tlg_NDT(TraceLoggingFileTimeFixedArray, pValues, __VA_ARGS__))
-#define TraceLoggingFileTimeUtcFixedArray(pValues, cValues, ...) _tlg_ArgIntFixedArray(uint64_t, (uint64_t const *)(pValues), cValues, _tlgHex, 0, _tlg_NDT(TraceLoggingFileTimeUtcFixedArray, pValues, __VA_ARGS__))
-#define TraceLoggingSystemTimeFixedArray(pValues, cValues, ...) _tlg_ArgIntFixedArray(uint16_t, (uint16_t const *)(pValues), (cValues)*8u, _tlgDecimal, 0, _tlg_NDT(TraceLoggingSystemTimeFixedArray, pValues, __VA_ARGS__))
-#define TraceLoggingSystemTimeUtcFixedArray(pValues, cValues, ...) _tlg_ArgIntFixedArray(uint16_t, (uint16_t const *)(pValues), (cValues)*8u, _tlgDecimal, 0, _tlg_NDT(TraceLoggingSystemTimeUtcFixedArray, pValues, __VA_ARGS__))
+
+#define TraceLoggingPointerFixedArray(pValues, cValues, ...)       _tlg_ArgFixedArray(void const*, pValues,                 cValues,    (lttngh_TypeHexIntPtr), _tlg_NDT(TraceLoggingPointerFixedArray, pValues, __VA_ARGS__))
+#define TraceLoggingCodePointerFixedArray(pValues, cValues, ...)   _tlg_ArgFixedArray(void const*, pValues,                 cValues,    (lttngh_TypeHexIntPtr), _tlg_NDT(TraceLoggingCodePointerFixedArray, pValues, __VA_ARGS__))
+#define TraceLoggingGuidFixedArray(pValues, cValues, ...)          _tlg_ArgFixedArray(uint8_t, (uint8_t const *)(pValues), (cValues)*16u,(lttngh_TypeHexInt8), _tlg_NDT(TraceLoggingGuidFixedArray, pValues, __VA_ARGS__))
+#define TraceLoggingFileTimeFixedArray(pValues, cValues, ...)      _tlg_ArgFixedArray(uint64_t, (uint64_t const *)(pValues), cValues,   (lttngh_TypeUInt64), _tlg_NDT(TraceLoggingFileTimeFixedArray, pValues, __VA_ARGS__))
+#define TraceLoggingFileTimeUtcFixedArray(pValues, cValues, ...)   _tlg_ArgFixedArray(uint64_t, (uint64_t const *)(pValues), cValues,   (lttngh_TypeUInt64), _tlg_NDT(TraceLoggingFileTimeUtcFixedArray, pValues, __VA_ARGS__))
+#define TraceLoggingSystemTimeFixedArray(pValues, cValues, ...)    _tlg_ArgFixedArray(uint16_t, (uint16_t const *)(pValues), (cValues)*8u,(lttngh_TypeUInt16), _tlg_NDT(TraceLoggingSystemTimeFixedArray, pValues, __VA_ARGS__))
+#define TraceLoggingSystemTimeUtcFixedArray(pValues, cValues, ...) _tlg_ArgFixedArray(uint16_t, (uint16_t const *)(pValues), (cValues)*8u,(lttngh_TypeUInt16), _tlg_NDT(TraceLoggingSystemTimeUtcFixedArray, pValues, __VA_ARGS__))
 
 // Broken (LTTNG-UST does not handle metadata for array-of-float):
-//#define TraceLoggingFloat32FixedArray(pValues, cValues, ...)          _tlg_ArgFloatFixedArray(float,  pValues, cValues,                 _tlg_NDT(TraceLoggingFloat32FixedArray, pValues, __VA_ARGS__))
-//#define TraceLoggingFloat64FixedArray(pValues, cValues, ...)          _tlg_ArgFloatFixedArray(double, pValues, cValues,                 _tlg_NDT(TraceLoggingFloat64FixedArray, pValues, __VA_ARGS__))
+//#define TraceLoggingFloat32FixedArray(pValues, cValues, ...)          _tlg_ArgFixedArray(float,  pValues, cValues, lttngh_TypeFloat32, _tlg_NDT(TraceLoggingFloat32FixedArray, pValues, __VA_ARGS__))
+//#define TraceLoggingFloat64FixedArray(pValues, cValues, ...)          _tlg_ArgFixedArray(double, pValues, cValues, lttngh_TypeFloat64, _tlg_NDT(TraceLoggingFloat64FixedArray, pValues, __VA_ARGS__))
 
 /*
 Wrapper macros for event fields with values that are variable-length arrays.
@@ -1149,7 +1134,7 @@ LTTNG-specific:
 - Violations of these rules cannot be detected by TraceLoggingProvider.h, but
   will likely cause problems when you try to decode the trace.
 - Be especially careful with automatically-generated field names, as they
-  often contain spaces other problematic symbols.
+  often contain spaces or other problematic symbols.
 
 If provided, the description parameter must be a string literal.
 (Field description is ignored for LTTNG.)
@@ -1163,45 +1148,47 @@ Examples:
 - TraceLoggingUInt8Array(pbX1, cbX1, "name", "desc")      // field name = "name", description = "desc", tags = 0.
 - TraceLoggingUInt8Array(pbX1, cbX1, "name", "desc", 0x4) // field name = "name", description = "desc", tags = 0x4.
 */
-#define TraceLoggingInt8Array(pValues, cValues, ...) _tlg_ArgIntArray(int8_t, pValues, cValues, _tlgDecimal, 1, _tlg_NDT(TraceLoggingInt8Array, pValues, __VA_ARGS__))
-#define TraceLoggingUInt8Array(pValues, cValues, ...) _tlg_ArgIntArray(uint8_t, pValues, cValues, _tlgDecimal, 0, _tlg_NDT(TraceLoggingUInt8Array, pValues, __VA_ARGS__))
-#define TraceLoggingInt16Array(pValues, cValues, ...) _tlg_ArgIntArray(int16_t, pValues, cValues, _tlgDecimal, 1, _tlg_NDT(TraceLoggingInt16Array, pValues, __VA_ARGS__))
-#define TraceLoggingUInt16Array(pValues, cValues, ...) _tlg_ArgIntArray(uint16_t, pValues, cValues, _tlgDecimal, 0, _tlg_NDT(TraceLoggingUInt16Array, pValues, __VA_ARGS__))
-#define TraceLoggingInt32Array(pValues, cValues, ...) _tlg_ArgIntArray(int32_t, pValues, cValues, _tlgDecimal, 1, _tlg_NDT(TraceLoggingInt32Array, pValues, __VA_ARGS__))
-#define TraceLoggingUInt32Array(pValues, cValues, ...) _tlg_ArgIntArray(uint32_t, pValues, cValues, _tlgDecimal, 0, _tlg_NDT(TraceLoggingUInt32Array, pValues, __VA_ARGS__))
-#define TraceLoggingLongArray(pValues, cValues, ...) _tlg_ArgIntArray(long, pValues, cValues, _tlgDecimal, 1, _tlg_NDT(TraceLoggingLongArray, pValues, __VA_ARGS__))
-#define TraceLoggingULongArray(pValues, cValues, ...) _tlg_ArgIntArray(unsigned long, pValues, cValues, _tlgDecimal, 0, _tlg_NDT(TraceLoggingULongArray, pValues, __VA_ARGS__))
-#define TraceLoggingInt64Array(pValues, cValues, ...) _tlg_ArgIntArray(int64_t, pValues, cValues, _tlgDecimal, 1, _tlg_NDT(TraceLoggingInt64Array, pValues, __VA_ARGS__))
-#define TraceLoggingUInt64Array(pValues, cValues, ...) _tlg_ArgIntArray(uint64_t, pValues, cValues, _tlgDecimal, 0, _tlg_NDT(TraceLoggingUInt64Array, pValues, __VA_ARGS__))
-#define TraceLoggingHexInt8Array(pValues, cValues, ...) _tlg_ArgIntArray(int8_t, pValues, cValues, _tlgHex, 0, _tlg_NDT(TraceLoggingHexInt8Array, pValues, __VA_ARGS__))
-#define TraceLoggingHexUInt8Array(pValues, cValues, ...) _tlg_ArgIntArray(uint8_t, pValues, cValues, _tlgHex, 0, _tlg_NDT(TraceLoggingHexUInt8Array, pValues, __VA_ARGS__))
-#define TraceLoggingHexInt16Array(pValues, cValues, ...) _tlg_ArgIntArray(int16_t, pValues, cValues, _tlgHex, 0, _tlg_NDT(TraceLoggingHexInt16Array, pValues, __VA_ARGS__))
-#define TraceLoggingHexUInt16Array(pValues, cValues, ...) _tlg_ArgIntArray(uint16_t, pValues, cValues, _tlgHex, 0, _tlg_NDT(TraceLoggingHexUInt16Array, pValues, __VA_ARGS__))
-#define TraceLoggingHexInt32Array(pValues, cValues, ...) _tlg_ArgIntArray(int32_t, pValues, cValues, _tlgHex, 0, _tlg_NDT(TraceLoggingHexInt32Array, pValues, __VA_ARGS__))
-#define TraceLoggingHexUInt32Array(pValues, cValues, ...) _tlg_ArgIntArray(uint32_t, pValues, cValues, _tlgHex, 0, _tlg_NDT(TraceLoggingHexUInt32Array, pValues, __VA_ARGS__))
-#define TraceLoggingHexLongArray(pValues, cValues, ...) _tlg_ArgIntArray(long, pValues, cValues, _tlgHex, 0, _tlg_NDT(TraceLoggingHexLongArray, pValues, __VA_ARGS__))
-#define TraceLoggingHexULongArray(pValues, cValues, ...) _tlg_ArgIntArray(unsigned long, pValues, cValues, _tlgHex, 0, _tlg_NDT(TraceLoggingHexULongArray, pValues, __VA_ARGS__))
-#define TraceLoggingHexInt64Array(pValues, cValues, ...) _tlg_ArgIntArray(int64_t, pValues, cValues, _tlgHex, 0, _tlg_NDT(TraceLoggingHexInt64Array, pValues, __VA_ARGS__))
-#define TraceLoggingHexUInt64Array(pValues, cValues, ...) _tlg_ArgIntArray(uint64_t, pValues, cValues, _tlgHex, 0, _tlg_NDT(TraceLoggingHexUInt64Array, pValues, __VA_ARGS__))
-#define TraceLoggingIntPtrArray(pValues, cValues, ...) _tlg_ArgIntArray(intptr_t, pValues, cValues, _tlgDecimal, 1, _tlg_NDT(TraceLoggingIntPtrArray, pValues, __VA_ARGS__))
-#define TraceLoggingUIntPtrArray(pValues, cValues, ...) _tlg_ArgIntArray(uintptr_t, pValues, cValues, _tlgDecimal, 0, _tlg_NDT(TraceLoggingUIntPtrArray, pValues, __VA_ARGS__))
-#define TraceLoggingBoolArray(pValues, cValues, ...) _tlg_ArgIntArray(int32_t, pValues, cValues, _tlgDecimal, 1, _tlg_NDT(TraceLoggingBoolArray, pValues, __VA_ARGS__))
-#define TraceLoggingBooleanArray(pValues, cValues, ...) _tlg_ArgIntArray(uint8_t, pValues, cValues, _tlgDecimal, 0, _tlg_NDT(TraceLoggingBooleanArray, pValues, __VA_ARGS__))
+#define TraceLoggingInt8Array(pValues, cValues, ...)            _tlg_ArgVarArray(int8_t,        pValues, cValues, (lttngh_TypeInt8Sequence), _tlg_NDT(TraceLoggingInt8Array, pValues, __VA_ARGS__))
+#define TraceLoggingUInt8Array(pValues, cValues, ...)           _tlg_ArgVarArray(uint8_t,       pValues, cValues, (lttngh_TypeUInt8Sequence), _tlg_NDT(TraceLoggingUInt8Array, pValues, __VA_ARGS__))
+#define TraceLoggingInt16Array(pValues, cValues, ...)           _tlg_ArgVarArray(int16_t,       pValues, cValues, (lttngh_TypeInt16Sequence), _tlg_NDT(TraceLoggingInt16Array, pValues, __VA_ARGS__))
+#define TraceLoggingUInt16Array(pValues, cValues, ...)          _tlg_ArgVarArray(uint16_t,      pValues, cValues, (lttngh_TypeUInt16Sequence), _tlg_NDT(TraceLoggingUInt16Array, pValues, __VA_ARGS__))
+#define TraceLoggingInt32Array(pValues, cValues, ...)           _tlg_ArgVarArray(int32_t,       pValues, cValues, (lttngh_TypeInt32Sequence), _tlg_NDT(TraceLoggingInt32Array, pValues, __VA_ARGS__))
+#define TraceLoggingUInt32Array(pValues, cValues, ...)          _tlg_ArgVarArray(uint32_t,      pValues, cValues, (lttngh_TypeUInt32Sequence), _tlg_NDT(TraceLoggingUInt32Array, pValues, __VA_ARGS__))
+#define TraceLoggingLongArray(pValues, cValues, ...)            _tlg_ArgVarArray(signed long,   pValues, cValues, (lttngh_TypeLongSequence), _tlg_NDT(TraceLoggingLongArray, pValues, __VA_ARGS__))
+#define TraceLoggingULongArray(pValues, cValues, ...)           _tlg_ArgVarArray(unsigned long, pValues, cValues, (lttngh_TypeULongSequence), _tlg_NDT(TraceLoggingULongArray, pValues, __VA_ARGS__))
+#define TraceLoggingInt64Array(pValues, cValues, ...)           _tlg_ArgVarArray(int64_t,       pValues, cValues, (lttngh_TypeInt64Sequence), _tlg_NDT(TraceLoggingInt64Array, pValues, __VA_ARGS__))
+#define TraceLoggingUInt64Array(pValues, cValues, ...)          _tlg_ArgVarArray(uint64_t,      pValues, cValues, (lttngh_TypeUInt64Sequence), _tlg_NDT(TraceLoggingUInt64Array, pValues, __VA_ARGS__))
+#define TraceLoggingHexInt8Array(pValues, cValues, ...)         _tlg_ArgVarArray(int8_t,        pValues, cValues, (lttngh_TypeHexInt8Sequence), _tlg_NDT(TraceLoggingHexInt8Array, pValues, __VA_ARGS__))
+#define TraceLoggingHexUInt8Array(pValues, cValues, ...)        _tlg_ArgVarArray(uint8_t,       pValues, cValues, (lttngh_TypeHexInt8Sequence), _tlg_NDT(TraceLoggingHexUInt8Array, pValues, __VA_ARGS__))
+#define TraceLoggingHexInt16Array(pValues, cValues, ...)        _tlg_ArgVarArray(int16_t,       pValues, cValues, (lttngh_TypeHexInt16Sequence), _tlg_NDT(TraceLoggingHexInt16Array, pValues, __VA_ARGS__))
+#define TraceLoggingHexUInt16Array(pValues, cValues, ...)       _tlg_ArgVarArray(uint16_t,      pValues, cValues, (lttngh_TypeHexInt16Sequence), _tlg_NDT(TraceLoggingHexUInt16Array, pValues, __VA_ARGS__))
+#define TraceLoggingHexInt32Array(pValues, cValues, ...)        _tlg_ArgVarArray(int32_t,       pValues, cValues, (lttngh_TypeHexInt32Sequence), _tlg_NDT(TraceLoggingHexInt32Array, pValues, __VA_ARGS__))
+#define TraceLoggingHexUInt32Array(pValues, cValues, ...)       _tlg_ArgVarArray(uint32_t,      pValues, cValues, (lttngh_TypeHexInt32Sequence), _tlg_NDT(TraceLoggingHexUInt32Array, pValues, __VA_ARGS__))
+#define TraceLoggingHexLongArray(pValues, cValues, ...)         _tlg_ArgVarArray(signed long,   pValues, cValues, (lttngh_TypeHexLongSequence), _tlg_NDT(TraceLoggingHexLongArray, pValues, __VA_ARGS__))
+#define TraceLoggingHexULongArray(pValues, cValues, ...)        _tlg_ArgVarArray(unsigned long, pValues, cValues, (lttngh_TypeHexLongSequence), _tlg_NDT(TraceLoggingHexULongArray, pValues, __VA_ARGS__))
+#define TraceLoggingHexInt64Array(pValues, cValues, ...)        _tlg_ArgVarArray(int64_t,       pValues, cValues, (lttngh_TypeHexInt64Sequence), _tlg_NDT(TraceLoggingHexInt64Array, pValues, __VA_ARGS__))
+#define TraceLoggingHexUInt64Array(pValues, cValues, ...)       _tlg_ArgVarArray(uint64_t,      pValues, cValues, (lttngh_TypeHexInt64Sequence), _tlg_NDT(TraceLoggingHexUInt64Array, pValues, __VA_ARGS__))
+#define TraceLoggingIntPtrArray(pValues, cValues, ...)          _tlg_ArgVarArray(intptr_t,      pValues, cValues, (lttngh_TypeHexIntPtrSequence), _tlg_NDT(TraceLoggingIntPtrArray, pValues, __VA_ARGS__))
+#define TraceLoggingUIntPtrArray(pValues, cValues, ...)         _tlg_ArgVarArray(uintptr_t,     pValues, cValues, (lttngh_TypeHexIntPtrSequence), _tlg_NDT(TraceLoggingUIntPtrArray, pValues, __VA_ARGS__))
+#define TraceLoggingBoolArray(pValues, cValues, ...)            _tlg_ArgVarArray(int32_t,       pValues, cValues, (lttngh_TypeBool32Sequence), _tlg_NDT(TraceLoggingBoolArray, pValues, __VA_ARGS__))
+#define TraceLoggingBooleanArray(pValues, cValues, ...)         _tlg_ArgVarArray(uint8_t,       pValues, cValues, (lttngh_TypeBool8Sequence), _tlg_NDT(TraceLoggingBooleanArray, pValues, __VA_ARGS__))
+
 #define TraceLoggingCharArray(pValues, cValues, ...) _tlg_ArgCountedString8(char, pValues, cValues, _tlg_NDT(TraceLoggingCharArray, pValues, __VA_ARGS__))
 #define TraceLoggingWCharArray(pValues, cValues, ...) _tlg_ArgCountedStringW(wchar_t, pValues, cValues, _tlg_NDT(TraceLoggingWCharArray, pValues, __VA_ARGS__))
 #define TraceLoggingChar16Array(pValues, cValues, ...) _tlg_ArgCountedStringNN(char16_t, pValues, cValues, 16, _tlg_NDT(TraceLoggingChar16Array, pValues, __VA_ARGS__))
 #define TraceLoggingChar32Array(pValues, cValues, ...) _tlg_ArgCountedStringNN(char32_t, pValues, cValues, 32, _tlg_NDT(TraceLoggingChar32Array, pValues, __VA_ARGS__))
-#define TraceLoggingPointerArray(pValues, cValues, ...) _tlg_ArgIntArray(void const *, pValues, cValues, _tlgHex, 0, _tlg_NDT(TraceLoggingPointerArray, pValues, __VA_ARGS__))
-#define TraceLoggingCodePointerArray(pValues, cValues, ...) _tlg_ArgIntArray(void const *, pValues, cValues, _tlgHex, 0, _tlg_NDT(TraceLoggingCodePointerArray, pValues, __VA_ARGS__))
-#define TraceLoggingGuidArray(pValues, cValues, ...) _tlg_ArgIntArray(uint8_t, (uint8_t const *)(pValues), (cValues)*16u, _tlgDecimal, 0, _tlg_NDT(TraceLoggingGuidArray, pValues, __VA_ARGS__))
-#define TraceLoggingFileTimeArray(pValues, cValues, ...) _tlg_ArgIntArray(uint64_t, (uint64_t const *)(pValues), cValues, _tlgHex, 0, _tlg_NDT(TraceLoggingFileTimeArray, pValues, __VA_ARGS__))
-#define TraceLoggingFileTimeUtcArray(pValues, cValues, ...) _tlg_ArgIntArray(uint64_t, (uint64_t const *)(pValues), cValues, _tlgHex, 0, _tlg_NDT(TraceLoggingFileTimeUtcArray, pValues, __VA_ARGS__))
-#define TraceLoggingSystemTimeArray(pValues, cValues, ...) _tlg_ArgIntArray(uint16_t, (uint16_t const *)(pValues), (cValues)*8u, _tlgDecimal, 0, _tlg_NDT(TraceLoggingSystemTimeArray, pValues, __VA_ARGS__))
-#define TraceLoggingSystemTimeUtcArray(pValues, cValues, ...) _tlg_ArgIntArray(uint16_t, (uint16_t const *)(pValues), (cValues)*8u, _tlgDecimal, 0, _tlg_NDT(TraceLoggingSystemTimeUtcArray, pValues, __VA_ARGS__))
 
-    // Broken (LTTNG-UST does not handle metadata for sequence-of-float):
-    //#define TraceLoggingFloat32Array(pValues, cValues, ...)          _tlg_ArgFloatArray(float,  pValues, cValues,                 _tlg_NDT(TraceLoggingFloat32Array, pValues, __VA_ARGS__))
-    //#define TraceLoggingFloat64Array(pValues, cValues, ...)          _tlg_ArgFloatArray(double, pValues, cValues,                 _tlg_NDT(TraceLoggingFloat64Array, pValues, __VA_ARGS__))
+#define TraceLoggingPointerArray(pValues, cValues, ...)         _tlg_ArgVarArray(void const*,   pValues,                cValues, (lttngh_TypeHexIntPtrSequence), _tlg_NDT(TraceLoggingPointerArray, pValues, __VA_ARGS__))
+#define TraceLoggingCodePointerArray(pValues, cValues, ...)     _tlg_ArgVarArray(void const*,   pValues,                cValues, (lttngh_TypeHexIntPtrSequence), _tlg_NDT(TraceLoggingCodePointerArray, pValues, __VA_ARGS__))
+#define TraceLoggingGuidArray(pValues, cValues, ...)            _tlg_ArgVarArray(uint8_t, (uint8_t const *)(pValues), (cValues)*16u, (lttngh_TypeHexInt8Sequence), _tlg_NDT(TraceLoggingGuidArray, pValues, __VA_ARGS__))
+#define TraceLoggingFileTimeArray(pValues, cValues, ...)        _tlg_ArgVarArray(uint64_t, (uint64_t const *)(pValues), cValues, (lttngh_TypeUInt64Sequence), _tlg_NDT(TraceLoggingFileTimeArray, pValues, __VA_ARGS__))
+#define TraceLoggingFileTimeUtcArray(pValues, cValues, ...)     _tlg_ArgVarArray(uint64_t, (uint64_t const *)(pValues), cValues, (lttngh_TypeUInt64Sequence), _tlg_NDT(TraceLoggingFileTimeUtcArray, pValues, __VA_ARGS__))
+#define TraceLoggingSystemTimeArray(pValues, cValues, ...)      _tlg_ArgVarArray(uint16_t, (uint16_t const *)(pValues), (cValues)*8u, (lttngh_TypeUInt16Sequence), _tlg_NDT(TraceLoggingSystemTimeArray, pValues, __VA_ARGS__))
+#define TraceLoggingSystemTimeUtcArray(pValues, cValues, ...)   _tlg_ArgVarArray(uint16_t, (uint16_t const *)(pValues), (cValues)*8u, (lttngh_TypeUInt16Sequence), _tlg_NDT(TraceLoggingSystemTimeUtcArray, pValues, __VA_ARGS__))
+
+// Broken (LTTNG-UST does not handle metadata for sequence-of-float):
+//#define TraceLoggingFloat32Array(pValues, cValues, ...)          _tlg_ArgFloatArray(float,  pValues, cValues,                 _tlg_NDT(TraceLoggingFloat32Array, pValues, __VA_ARGS__))
+//#define TraceLoggingFloat64Array(pValues, cValues, ...)          _tlg_ArgFloatArray(double, pValues, cValues,                 _tlg_NDT(TraceLoggingFloat64Array, pValues, __VA_ARGS__))
 
 #ifdef __EDG__
 #pragma endregion
@@ -1385,17 +1372,17 @@ Examples:
     // For TraceLogging-internal use only.
     struct _tlg_Provider_t
     {
-        struct lttng_probe_desc ProbeDesc;
-        int IsRegistered;
+        lttngh_ust_probe_desc ProbeDesc;
+        lttngh_registration  Registration;
     };
 
     // For TraceLogging-internal use only.
     struct _tlg_Event_t
     {
-        struct lttng_event_desc Desc; // MUST be first field.
+        lttngh_ust_event_desc Desc; // MUST be first field.
         uint64_t Keyword;
-        struct lttng_ust_tracepoint const *ProbePtr;
-        char const *Name;
+        struct lttng_ust_tracepoint *ProbePtr; // Non-const so we can update provider_name.
+        char const *EventBaseName;
         int const *LevelPtr;
         int Level;
     };
@@ -1408,42 +1395,52 @@ Examples:
 #pragma region Internal helper functions
 #endif
 
+    // For TraceLogging-internal use only.
+    // Before 2.13: Sets _tlg_fullName = ProviderName + ":" + EventName + ";" + KeywordSuffix
+    // After 2.13: Sets _tlg_fullName = EventName + ";" + KeywordSuffix
     unsigned _tlg_EventFullName(
-        char *pFullName,
+        char *_tlg_fullName,
+#if lttngh_UST_VER < 213
         char const *pchProviderName,
         unsigned cchProviderName,
+#endif // lttngh_UST_VER
         char const *pchEventName,
         unsigned cchEventName,
         uint64_t keyword)
         _tlg_NOEXCEPT _tlg_WEAK_ATTRIBUTES;
     unsigned _tlg_EventFullName(
-        char *pFullName,
-        char const *pchProviderName,
+        char *_tlg_fullName,
+#if lttngh_UST_VER < 213
+        char const* pchProviderName,
         unsigned cchProviderName,
+#endif // lttngh_UST_VER
         char const *pchEventName,
         unsigned cchEventName,
         uint64_t keyword)
         _tlg_NOEXCEPT
     {
-        char *pOut = pFullName;
-        char const *const pOutEnd = pOut + (LTTNG_UST_SYM_NAME_LEN - 1);
+        char *pOut = _tlg_fullName;
+        char const *const pOutEnd = pOut + (lttngh_UST_SYM_NAME_LEN - 1);
 
+#if lttngh_UST_VER < 213
         // ProviderName + ":" + EventName + ";k;" must be less than 256 characters.
-        if (cchProviderName + cchEventName > LTTNG_UST_SYM_NAME_LEN - 5)
+        if (cchProviderName + cchEventName > lttngh_UST_SYM_NAME_LEN - 5)
         {
             // If not, truncate event name.
             _tlg_ASSERT(!"ProviderName+EventName+KeywordSuffix too long");
             // The macros check for this (static_assert), but just in case...
-            if (cchProviderName > LTTNG_UST_SYM_NAME_LEN - 5)
+            if (cchProviderName > lttngh_UST_SYM_NAME_LEN - 5)
             {
-                cchProviderName = LTTNG_UST_SYM_NAME_LEN - 5;
+                cchProviderName = lttngh_UST_SYM_NAME_LEN - 5;
             }
-            cchEventName = (LTTNG_UST_SYM_NAME_LEN - 5) - cchProviderName;
+            cchEventName = (lttngh_UST_SYM_NAME_LEN - 5) - cchProviderName;
         }
 
         memcpy(pOut, pchProviderName, cchProviderName);
         pOut += cchProviderName;
         *pOut++ = ':';
+#endif // lttngh_UST_VER
+
         pOut = (char *)memcpy(pOut, pchEventName, cchEventName);
         pOut += cchEventName;
 
@@ -1488,48 +1485,66 @@ Examples:
         }
 
         *pOut = 0; // nul-termination (but not included in returned character count)
-        return (unsigned)(pOut - pFullName);
+        return (unsigned)(pOut - _tlg_fullName);
     }
 
     int _tlg_EventEnabled(
         struct _tlg_Provider_t *pProvider,
         char const *eventName,
-        struct lttng_event_desc const **pEventDescStart,
-        struct lttng_event_desc const **pEventDescStop,
+        lttngh_ust_event_desc const **pEventDescStart,
+        lttngh_ust_event_desc const **pEventDescStop,
         int const **ppState)
         _tlg_NOEXCEPT _tlg_WEAK_ATTRIBUTES;
     int _tlg_EventEnabled(
         struct _tlg_Provider_t *pProvider,
         char const *eventName,
-        struct lttng_event_desc const **pEventDescStart,
-        struct lttng_event_desc const **pEventDescStop,
+        lttngh_ust_event_desc const **pEventDescStart,
+        lttngh_ust_event_desc const **pEventDescStop,
         int const **ppState)
         _tlg_NOEXCEPT
     {
         static const int NullState = 0;
         int state = 0;
 
-        if (__atomic_load_n(&pProvider->IsRegistered, __ATOMIC_ACQUIRE) == 1)
+        int const registrationState =
+            __atomic_load_n(lttngh_REGISTRATION_STATE(pProvider->Registration), __ATOMIC_ACQUIRE);
+        if (registrationState == 1)
         {
-            char pchEventFullName[LTTNG_UST_SYM_NAME_LEN];
-            unsigned const cchEventFullName = _tlg_EventFullName(
-                pchEventFullName,
-                pProvider->ProbeDesc.provider, (unsigned)strlen(pProvider->ProbeDesc.provider),
-                eventName, (unsigned)strlen(eventName),
-                0) - 3; // Don't add keyword suffix.
-
-            for (struct lttng_event_desc const **ppDesc = pEventDescStart; ppDesc != pEventDescStop; ppDesc += 1)
+#if lttngh_UST_VER >= 213
+            unsigned const cchEventName = (unsigned)strlen(eventName);
+            for (lttngh_ust_event_desc const **ppDesc = pEventDescStart; ppDesc != pEventDescStop; ppDesc += 1)
             {
                 struct _tlg_Event_t *pEvent = (struct _tlg_Event_t *)*ppDesc;
                 if (pEvent != NULL &&
-                    0 == strncmp(pchEventFullName, pEvent->Desc.name, cchEventFullName) && // Ignore keyword suffix.
-                    (pEvent->Desc.name[cchEventFullName] == 0 || pEvent->Desc.name[cchEventFullName] == ';'))
+                    &pProvider->ProbeDesc == pEvent->Desc.probe_desc &&
+                    0 == strncmp(eventName, pEvent->Desc.event_name, cchEventName) && // Ignore keyword suffix.
+                    (pEvent->Desc.event_name[cchEventName] == ';' || pEvent->Desc.event_name[cchEventName] == '\0'))
                 {
                     __atomic_store_n(ppState, &pEvent->ProbePtr->state, __ATOMIC_RELAXED);
                     state = CMM_LOAD_SHARED(pEvent->ProbePtr->state);
                     goto Done;
                 }
             }
+#else // lttngh_UST_VER
+            char _tlg_fullName[lttngh_UST_SYM_NAME_LEN];
+            unsigned const cchEventFullName = _tlg_EventFullName(
+                _tlg_fullName,
+                pProvider->ProbeDesc.provider, (unsigned)strlen(pProvider->ProbeDesc.provider),
+                eventName, (unsigned)strlen(eventName),
+                0) - 3; // Ignore keywords - force ";k;" suffix, then chop it off.
+            for (lttngh_ust_event_desc const **ppDesc = pEventDescStart; ppDesc != pEventDescStop; ppDesc += 1)
+            {
+                struct _tlg_Event_t *pEvent = (struct _tlg_Event_t *)*ppDesc;
+                if (pEvent != NULL &&
+                    0 == strncmp(_tlg_fullName, pEvent->Desc.name, cchEventFullName) && // Ignore keyword suffix.
+                    (pEvent->Desc.name[cchEventFullName] == ';' || pEvent->Desc.name[cchEventFullName] == '\0'))
+                {
+                    __atomic_store_n(ppState, &pEvent->ProbePtr->state, __ATOMIC_RELAXED);
+                    state = CMM_LOAD_SHARED(pEvent->ProbePtr->state);
+                    goto Done;
+                }
+            }
+#endif // lttngh_UST_VER
 
             _tlg_ASSERT(!"TraceLoggingEventEnabled called with invalid event name");
             __atomic_store_n(ppState, &NullState, __ATOMIC_RELAXED);
@@ -1549,61 +1564,91 @@ Examples:
         struct lttng_ust_tracepoint *const *pTracepointStart)
         _tlg_NOEXCEPT
     {
+        (void)pTracepointStart;
         return lttngh_UnregisterProvider(
-            &pProvider->IsRegistered,
+            &pProvider->Registration
+#if lttngh_UST_VER < 213
+            ,
             &pProvider->ProbeDesc,
-            pTracepointStart);
+            pTracepointStart
+#endif // lttngh_UST_VER
+            );
     }
 
     int _tlg_ProviderRegister(
         struct _tlg_Provider_t *pProvider,
         struct lttng_ust_tracepoint **pTracepointStart,
         struct lttng_ust_tracepoint **pTracepointStop,
-        struct lttng_event_desc const **pEventDescStart,
-        struct lttng_event_desc const **pEventDescStop)
+        lttngh_ust_event_desc const **pEventDescStart,
+        lttngh_ust_event_desc const **pEventDescStop)
         _tlg_NOEXCEPT _tlg_WEAK_ATTRIBUTES;
     int _tlg_ProviderRegister(
         struct _tlg_Provider_t *pProvider,
         struct lttng_ust_tracepoint **pTracepointStart,
         struct lttng_ust_tracepoint **pTracepointStop,
-        struct lttng_event_desc const **pEventDescStart,
-        struct lttng_event_desc const **pEventDescStop)
+        lttngh_ust_event_desc const **pEventDescStart,
+        lttngh_ust_event_desc const **pEventDescStop)
         _tlg_NOEXCEPT
     {
         // Fix up event names, then call lttngh_RegisterProvider.
 
-        char const *const pchProvName = pProvider->ProbeDesc.provider;
+#if lttngh_UST_VER < 213
+        char const *const pchProvName = lttngh_PROVIDER_NAME(pProvider->ProbeDesc);
         unsigned const cchProvName = (unsigned)strlen(pchProvName);
+#endif // lttngh_UST_VER
 
-        if (__atomic_exchange_n(&pProvider->IsRegistered, 2, __ATOMIC_RELAXED) != 0)
+        int oldRegistrationState;
+
+        oldRegistrationState = __atomic_exchange_n(lttngh_REGISTRATION_STATE(pProvider->Registration), 2, __ATOMIC_RELAXED);
+        if (oldRegistrationState != 0)
         {
             // Called TraceLoggingRegister on an already-registered handle.
             // (Or memory corruption?)
             abort();
         }
 
-        for (struct lttng_event_desc const **ppDesc = pEventDescStart;
+        for (lttngh_ust_event_desc const **ppDesc = pEventDescStart;
              ppDesc != pEventDescStop; ppDesc += 1)
         {
-            struct _tlg_Event_t *pEvent = (struct _tlg_Event_t *)*ppDesc;
-            if (pEvent != NULL && pEvent->Desc.name[0] == 0)
+            struct _tlg_Event_t const* pEvent = (struct _tlg_Event_t const*)*ppDesc;
+            if (pEvent != NULL)
             {
-                _tlg_EventFullName(
-                    (char *)pEvent->Desc.name,
-                    pchProvName, cchProvName,
-                    pEvent->Name, (unsigned)strlen(pEvent->Name),
-                    pEvent->Keyword);
+#if lttngh_UST_VER >= 213
+                _tlg_ASSERT(pEvent->ProbePtr->event_name == pEvent->Desc.event_name);
+                if (pEvent->Desc.event_name[0] == 0)
+                {
+                    char* _tlg_fullName = (char*)pEvent->Desc.event_name;
+                    _tlg_EventFullName(
+                        _tlg_fullName,
+                        pEvent->EventBaseName, (unsigned)strlen(pEvent->EventBaseName),
+                        pEvent->Keyword);
+                    _tlg_ASSERT(pEvent->ProbePtr->provider_name == NULL);
+                    pEvent->ProbePtr->provider_name = pProvider->ProbeDesc.provider_name;
+                }
+#else // lttngh_UST_VER
+                _tlg_ASSERT(pEvent->ProbePtr->name == pEvent->Desc.name);
+                if (pEvent->Desc.name[0] == 0)
+                {
+                    char* _tlg_fullName = (char*)pEvent->Desc.name;
+                    _tlg_EventFullName(
+                        _tlg_fullName,
+                        pchProvName, cchProvName,
+                        pEvent->EventBaseName, (unsigned)strlen(pEvent->EventBaseName),
+                        pEvent->Keyword);
+                }
+#endif // lttngh_UST_VER
             }
         }
 
-        if (__atomic_exchange_n(&pProvider->IsRegistered, 0, __ATOMIC_RELEASE) != 2)
+        oldRegistrationState = __atomic_exchange_n(lttngh_REGISTRATION_STATE(pProvider->Registration), 0, __ATOMIC_RELEASE);
+        if (oldRegistrationState != 2)
         {
             // Should never happen. (Memory corruption?)
             abort();
         }
 
         return lttngh_RegisterProvider(
-            &pProvider->IsRegistered,
+            &pProvider->Registration,
             &pProvider->ProbeDesc,
             pTracepointStart,
             pTracepointStop,
@@ -1614,7 +1659,7 @@ Examples:
     static inline char const *_tlg_ProviderName(struct _tlg_Provider_t *pProvider) _tlg_NOEXCEPT _tlg_INLINE_ATTRIBUTES;
     static inline char const *_tlg_ProviderName(struct _tlg_Provider_t *pProvider) _tlg_NOEXCEPT
     {
-        return pProvider->ProbeDesc.provider;
+        return lttngh_PROVIDER_NAME(pProvider->ProbeDesc);
     }
 
     static inline uint16_t _tlg_SidSize(void const *pSid) _tlg_NOEXCEPT _tlg_INLINE_ATTRIBUTES;
@@ -1640,7 +1685,7 @@ Examples:
         _tlg_NOEXCEPT
     {
         uint16_t const *const pLength = &pDesc[1].Length;
-        pDesc[0] = lttngh_DataDescCreate(pLength, sizeof(uint16_t), lttng_alignof(uint16_t), lttngh_DataType_None);
+        pDesc[0] = lttngh_DataDescCreate(pLength, sizeof(uint16_t), lttngh_ALIGNOF(uint16_t), lttngh_DataType_None);
         pDesc[1] = lttngh_DataDescCreateCounted(pVals, cVals * cbVal, alignment, cVals);
     }
 
@@ -1659,8 +1704,8 @@ Examples:
         unsigned char alignment)
         _tlg_NOEXCEPT
     {
-        uint8_t const *const pLength = (uint8_t const *)&pDesc[1].Length + (BYTE_ORDER == BIG_ENDIAN);
-        pDesc[0] = lttngh_DataDescCreate(pLength, sizeof(uint8_t), lttng_alignof(uint8_t), lttngh_DataType_None);
+        uint8_t const *const pLength = (uint8_t const *)&pDesc[1].Length + (__BYTE_ORDER == __BIG_ENDIAN);
+        pDesc[0] = lttngh_DataDescCreate(pLength, sizeof(uint8_t), lttngh_ALIGNOF(uint8_t), lttngh_DataType_None);
         pDesc[1] = lttngh_DataDescCreateCounted(pVals, cVals * cbVal, alignment, cVals);
     }
 
@@ -1675,28 +1720,6 @@ Examples:
 #ifdef __EDG__
 #pragma region Internal implementation macros
 #endif
-
-#define _tlg_IntDataSigned0 lttngh_DataType_Unsigned
-#define _tlg_IntDataSigned1 lttngh_DataType_Signed
-
-#define _tlg_IntFieldType_tlgDecimal \
-    0, 10, lttng_encode_none, {} // byteswap, radix, encoding, padding
-#define _tlg_IntFieldType_tlgHex \
-    0, 16, lttng_encode_none, {} // byteswap, radix, encoding, padding
-#if BYTE_ORDER == LITTLE_ENDIAN
-#define _tlg_IntFieldType_tlgDecimalBE \
-    1, 10, lttng_encode_none, {} // byteswap, radix, encoding, padding
-#else
-#define _tlg_IntFieldType_tlgDecimalBE \
-    0, 10, lttng_encode_none, {} // byteswap, radix, encoding, padding
-#endif
-#define _tlg_IntFieldType_tlgUTF8 \
-    0, 10, lttng_encode_UTF8, {} // byteswap, radix, encoding, padding
-
-#define _tlg_FloatFieldType_float \
-    8, 24, 8u * lttng_alignof(float), 0, {} // exponent, mantissa, align, byteswap, padding
-#define _tlg_FloatFieldType_double \
-    11, 53, 8u * lttng_alignof(double), 0, {} // exponent, mantissa, align, byteswap, padding
 
 #ifdef __cplusplus
 
@@ -1763,6 +1786,13 @@ struct _tlgDecay
     typedef typename _tlgDecay_impl<typename _tlgRemoveReference<T>::type>::type type;
 };
 
+// Temporary storage for a nul-terminated character string of length 1.
+template<class ctype>
+struct _tlgCharBuf
+{
+    ctype _tlgBuf[2];
+};
+
 // Data descriptor creation (general):
 
 template <class ctype>
@@ -1770,7 +1800,7 @@ inline void _tlgCppInit1Desc(struct lttngh_DataDesc &desc, ctype const &value, l
 template <class ctype>
 inline void _tlgCppInit1Desc(struct lttngh_DataDesc &desc, ctype const &value, lttngh_DataType type) _tlg_NOEXCEPT
 {
-    desc = lttngh_DataDescCreate(&value, sizeof(ctype), lttng_alignof(ctype), type);
+    desc = lttngh_DataDescCreate(&value, sizeof(ctype), lttngh_ALIGNOF(ctype), type);
 }
 
 template <class ctype, uint16_t cValues, class T>
@@ -1778,7 +1808,7 @@ inline void _tlgCppInit1DescByRef(struct lttngh_DataDesc &desc, T const &value) 
 template <class ctype, uint16_t cValues, class T>
 inline void _tlgCppInit1DescByRef(struct lttngh_DataDesc &desc, T const &value) _tlg_NOEXCEPT
 {
-    desc = lttngh_DataDescCreateCounted(&value, cValues * sizeof(ctype), lttng_alignof(ctype), cValues);
+    desc = lttngh_DataDescCreateCounted(&value, cValues * sizeof(ctype), lttngh_ALIGNOF(ctype), cValues);
 }
 
 template <class ctype, uint16_t cValues>
@@ -1786,7 +1816,7 @@ inline void _tlgCppInit1DescFixedArray(struct lttngh_DataDesc &desc, ctype const
 template <class ctype, uint16_t cValues>
 inline void _tlgCppInit1DescFixedArray(struct lttngh_DataDesc &desc, ctype const *pValues) _tlg_NOEXCEPT
 {
-    desc = lttngh_DataDescCreateCounted(pValues, cValues * sizeof(ctype), lttng_alignof(ctype), cValues);
+    desc = lttngh_DataDescCreateCounted(pValues, cValues * sizeof(ctype), lttngh_ALIGNOF(ctype), cValues);
 }
 
 template <class ctype>
@@ -1853,33 +1883,39 @@ inline void _tlgCppInit1DescSeqUtf32(struct lttngh_DataDesc &desc, ctype const *
 }
 
 template <class ctype>
-inline void _tlgCppInit1DescWchar(struct lttngh_DataDesc &desc, ctype const &value) _tlg_NOEXCEPT _tlg_INLINE_ATTRIBUTES;
+inline void _tlgCppInit1DescWchar(struct lttngh_DataDesc &desc, ctype const &value, _tlgCharBuf<wchar_t>&& buf = _tlgCharBuf<wchar_t>()) _tlg_NOEXCEPT _tlg_INLINE_ATTRIBUTES;
 template <class ctype>
-inline void _tlgCppInit1DescWchar(struct lttngh_DataDesc &desc, ctype const &value) _tlg_NOEXCEPT
+inline void _tlgCppInit1DescWchar(struct lttngh_DataDesc &desc, ctype const &value, _tlgCharBuf<wchar_t>&& buf) _tlg_NOEXCEPT
 {
     static_assert(sizeof(ctype) == sizeof(wchar_t), "Wrong char size");
-    desc = lttngh_DataDescCreateSequenceWchar((wchar_t const *)&value, 1);
+    buf._tlgBuf[0] = (wchar_t)value;
+    buf._tlgBuf[1] = L'\0';
+    desc = lttngh_DataDescCreateStringWchar(buf._tlgBuf);
 }
 
 template <class ctype>
-inline void _tlgCppInit1DescChar16(struct lttngh_DataDesc &desc, ctype const &value) _tlg_NOEXCEPT _tlg_INLINE_ATTRIBUTES;
+inline void _tlgCppInit1DescChar16(struct lttngh_DataDesc &desc, ctype const &value, _tlgCharBuf<char16_t>&& buf = _tlgCharBuf<char16_t>()) _tlg_NOEXCEPT _tlg_INLINE_ATTRIBUTES;
 template <class ctype>
-inline void _tlgCppInit1DescChar16(struct lttngh_DataDesc &desc, ctype const &value) _tlg_NOEXCEPT
+inline void _tlgCppInit1DescChar16(struct lttngh_DataDesc &desc, ctype const &value, _tlgCharBuf<char16_t>&& buf) _tlg_NOEXCEPT
 {
     static_assert(sizeof(ctype) == sizeof(char16_t), "Wrong char size");
-    desc = lttngh_DataDescCreateSequenceUtf16((char16_t const *)&value, 1);
+    buf._tlgBuf[0] = (char16_t)value;
+    buf._tlgBuf[1] = u'\0';
+    desc = lttngh_DataDescCreateStringUtf16(buf._tlgBuf);
 }
 
 template <class ctype>
-inline void _tlgCppInit1DescChar32(struct lttngh_DataDesc &desc, ctype const &value) _tlg_NOEXCEPT _tlg_INLINE_ATTRIBUTES;
+inline void _tlgCppInit1DescChar32(struct lttngh_DataDesc &desc, ctype const &value, _tlgCharBuf<char32_t>&& buf = _tlgCharBuf<char32_t>()) _tlg_NOEXCEPT _tlg_INLINE_ATTRIBUTES;
 template <class ctype>
-inline void _tlgCppInit1DescChar32(struct lttngh_DataDesc &desc, ctype const &value) _tlg_NOEXCEPT
+inline void _tlgCppInit1DescChar32(struct lttngh_DataDesc &desc, ctype const &value, _tlgCharBuf<char32_t>&& buf) _tlg_NOEXCEPT
 {
     static_assert(sizeof(ctype) == sizeof(char32_t), "Wrong char size");
-    desc = lttngh_DataDescCreateSequenceUtf32((char32_t const *)&value, 1);
+    buf._tlgBuf[0] = (char32_t)value;
+    buf._tlgBuf[1] = U'\0';
+    desc = lttngh_DataDescCreateStringUtf32(buf._tlgBuf);
 }
 
-template <class ctype, unsigned cbValue = sizeof(ctype), unsigned char alignment = lttng_alignof(ctype)>
+template <class ctype, unsigned cbValue = sizeof(ctype), unsigned char alignment = lttngh_ALIGNOF(ctype)>
 inline void _tlgCppInit2DescArray(struct lttngh_DataDesc *pDesc, ctype const *pValues, uint16_t cValues) _tlg_NOEXCEPT _tlg_INLINE_ATTRIBUTES;
 template <class ctype, unsigned cbValue, unsigned char alignment>
 inline void _tlgCppInit2DescArray(struct lttngh_DataDesc *pDesc, ctype const *pValues, uint16_t cValues) _tlg_NOEXCEPT
@@ -1887,7 +1923,7 @@ inline void _tlgCppInit2DescArray(struct lttngh_DataDesc *pDesc, ctype const *pV
     _tlg_DataDescCreateArray(pDesc, pValues, cValues, cbValue, alignment);
 }
 
-template <class ctype, unsigned cbValue = sizeof(uint8_t), unsigned char alignment = lttng_alignof(uint8_t)>
+template <class ctype, unsigned cbValue = sizeof(uint8_t), unsigned char alignment = lttngh_ALIGNOF(uint8_t)>
 inline void _tlgCppInit2DescBuffer(struct lttngh_DataDesc *pDesc, ctype const *pValue) _tlg_NOEXCEPT _tlg_INLINE_ATTRIBUTES;
 template <class ctype, unsigned cbValue, unsigned char alignment>
 inline void _tlgCppInit2DescBuffer(struct lttngh_DataDesc *pDesc, ctype const *pValue) _tlg_NOEXCEPT
@@ -1900,64 +1936,45 @@ inline void _tlgCppInit2DescSid(struct lttngh_DataDesc *pDesc, ctype const *pVal
 template <class ctype>
 inline void _tlgCppInit2DescSid(struct lttngh_DataDesc *pDesc, ctype const *pValue) _tlg_NOEXCEPT
 {
-    _tlg_DataDescCreateArray(pDesc, pValue, _tlg_SidSize(pValue), sizeof(uint8_t), lttng_alignof(uint8_t));
+    _tlg_DataDescCreateArray(pDesc, pValue, _tlg_SidSize(pValue), sizeof(uint8_t), lttngh_ALIGNOF(uint8_t));
 }
 
 template <class ctype>
-inline void _tlgCppInit2DescGuidPtr(struct lttngh_DataDesc *pDesc, ctype const *pValue) _tlg_NOEXCEPT _tlg_INLINE_ATTRIBUTES;
+inline void _tlgCppInit2DescActivityId(struct lttngh_DataDesc *pDesc, ctype const *pValue) _tlg_NOEXCEPT _tlg_INLINE_ATTRIBUTES;
 template <class ctype>
-inline void _tlgCppInit2DescGuidPtr(struct lttngh_DataDesc *pDesc, ctype const *pValue) _tlg_NOEXCEPT
+inline void _tlgCppInit2DescActivityId(struct lttngh_DataDesc *pDesc, ctype const *pValue) _tlg_NOEXCEPT
 {
-    _tlg_DataDescCreateTinyArray(pDesc, pValue, pValue ? 16 : 0, sizeof(uint8_t), lttng_alignof(uint8_t));
+    _tlg_DataDescCreateTinyArray(pDesc, pValue, pValue ? 16 : 0, sizeof(uint8_t), lttngh_ALIGNOF(uint8_t));
 }
 
 // Data descriptor creation (TraceLoggingValue):
 
-template <unsigned size, unsigned align, bool isSigned>
+template <unsigned size, bool isSigned>
 struct _tlgTypeMapInt
 {
-    static constexpr lttng_type _tlgLttngType =
-        {atype_integer, {.basic = {.integer = {8u * size, 8u * align, isSigned, _tlg_IntFieldType_tlgDecimal}}}};
-
     static const lttngh_DataType _tlgType = isSigned ? lttngh_DataType_Signed : lttngh_DataType_Unsigned;
-    static inline constexpr lttng_event_field _tlgField(char const *szName) _tlg_NOEXCEPT
+    static inline constexpr lttngh_ust_event_field _tlgField(char const *szName) _tlg_NOEXCEPT
     {
-        return {szName, _tlgLttngType, 0, {}};
+        typedef lttngh_UstTypeInt<size, isSigned> _tlgUstType;
+        return lttngh_INIT_EVENT_FIELD(szName, _tlgUstType::ust_type);
     }
 };
 
-template <unsigned size, unsigned align>
+template <unsigned size>
 struct _tlgTypeMapHexInt
 {
-    static constexpr lttng_type _tlgLttngType =
-        {atype_integer, {.basic = {.integer = {8u * size, 8u * align, 0, _tlg_IntFieldType_tlgHex}}}};
-
     static const lttngh_DataType _tlgType = lttngh_DataType_Unsigned;
-    static inline constexpr lttng_event_field _tlgField(char const *szName) _tlg_NOEXCEPT
+    static inline constexpr lttngh_ust_event_field _tlgField(char const *szName) _tlg_NOEXCEPT
     {
-        return {szName, _tlgLttngType, 0, {}};
+        return lttngh_INIT_EVENT_FIELD(szName, lttngh_UstTypeHexInt<size>::ust_type);
     }
 };
 
 struct _tlgTypeMapUtf8String
 {
-    static constexpr lttng_type _tlgLttngType =
-        {atype_string, {.basic = {.string = {lttng_encode_UTF8}}}};
-
-    static inline constexpr lttng_event_field _tlgField(char const *szName) _tlg_NOEXCEPT
+    static inline constexpr lttngh_ust_event_field _tlgField(char const *szName) _tlg_NOEXCEPT
     {
-        return {szName, _tlgLttngType, 0, {}};
-    }
-};
-
-struct _tlgTypeMapUtf8Sequence
-{
-    static constexpr lttng_type _tlgLttngType =
-        {atype_sequence, {.sequence = {{atype_integer, {.basic = {.integer = {8u * sizeof(uint16_t), 8u * lttng_alignof(uint16_t), 0, _tlg_IntFieldType_tlgDecimal}}}}, {atype_integer, {.basic = {.integer = {8u * sizeof(char), 8u * lttng_alignof(char), 0, _tlg_IntFieldType_tlgUTF8}}}}}}};
-
-    static inline constexpr lttng_event_field _tlgField(char const *szName) _tlg_NOEXCEPT
-    {
-        return {szName, _tlgLttngType, 0, {}};
+        return lttngh_INIT_EVENT_FIELD(szName, lttngh_TypeUtf8String);
     }
 };
 
@@ -1974,14 +1991,14 @@ struct _tlgTypeMap : _tlgTypeMapBase<typename _tlgDecay<T>::type>
 
 // The following type maps are covered by the template _tlgCppInit1DescAuto:
 
-#define _tlgTypeMapDeclInt(T)                                                               \
-    template <>                                                                             \
-    struct _tlgTypeMapBase<signed T> : _tlgTypeMapInt<sizeof(T), lttng_alignof(T), true>    \
-    {                                                                                       \
-    };                                                                                      \
-    template <>                                                                             \
-    struct _tlgTypeMapBase<unsigned T> : _tlgTypeMapInt<sizeof(T), lttng_alignof(T), false> \
-    {                                                                                       \
+#define _tlgTypeMapDeclInt(T)                                      \
+    template <>                                                    \
+    struct _tlgTypeMapBase<signed T> : _tlgTypeMapInt<sizeof(T), true>    \
+    {                                                              \
+    };                                                             \
+    template <>                                                    \
+    struct _tlgTypeMapBase<unsigned T> : _tlgTypeMapInt<sizeof(T), false> \
+    {                                                              \
     }
 _tlgTypeMapDeclInt(char);
 _tlgTypeMapDeclInt(short);
@@ -1991,56 +2008,41 @@ _tlgTypeMapDeclInt(long long);
 #undef _tlgTypeMapDeclInt
 
 template <>
-struct _tlgTypeMapBase<void *> : _tlgTypeMapHexInt<sizeof(void *), lttng_alignof(void *)>
+struct _tlgTypeMapBase<void *> : _tlgTypeMapHexInt<sizeof(void *)>
 {
 };
 template <>
-struct _tlgTypeMapBase<void const *> : _tlgTypeMapHexInt<sizeof(void const *), lttng_alignof(void const *)>
+struct _tlgTypeMapBase<void const *> : _tlgTypeMapHexInt<sizeof(void const *)>
 {
 };
 
 template <>
 struct _tlgTypeMapBase<bool>
 {
-    static constexpr lttng_type _tlgLttngType =
-        {atype_enum, {.basic = {.enumeration =
-#ifdef USE_LTTNG_2_7
-                                {.name = "bool" }
-#else
-                                    {&lttngh_BoolEnumDesc, {8u * sizeof(bool), 8u * lttng_alignof(bool), 0, _tlg_IntFieldType_tlgDecimal}}
-#endif
-                      }}};
-
     static const lttngh_DataType _tlgType = lttngh_DataType_Unsigned;
-    static inline constexpr lttng_event_field _tlgField(char const *szName) _tlg_NOEXCEPT
+    static inline constexpr lttngh_ust_event_field _tlgField(char const *szName) _tlg_NOEXCEPT
     {
-        return {szName, _tlgLttngType, 0, {}};
+        return lttngh_INIT_EVENT_FIELD(szName, lttngh_UstTypeBool<sizeof(bool)>::ust_type);
     }
 };
 
 template <>
 struct _tlgTypeMapBase<float>
 {
-    static constexpr lttng_type _tlgLttngType =
-        {atype_float, {.basic = {._float = {_tlg_FloatFieldType_float}}}};
-
     static const lttngh_DataType _tlgType = lttngh_DataType_Float;
-    static inline constexpr lttng_event_field _tlgField(char const *szName) _tlg_NOEXCEPT
+    static inline constexpr lttngh_ust_event_field _tlgField(char const *szName) _tlg_NOEXCEPT
     {
-        return {szName, _tlgLttngType, 0, {}};
+        return lttngh_INIT_EVENT_FIELD(szName, lttngh_UstTypeFloat<sizeof(float)>::ust_type);
     }
 };
 
 template <>
 struct _tlgTypeMapBase<double>
 {
-    static constexpr lttng_type _tlgLttngType =
-        {atype_float, {.basic = {._float = {_tlg_FloatFieldType_double}}}};
-
     static const lttngh_DataType _tlgType = lttngh_DataType_Float;
-    static inline constexpr lttng_event_field _tlgField(char const *szName) _tlg_NOEXCEPT
+    static inline constexpr lttngh_ust_event_field _tlgField(char const *szName) _tlg_NOEXCEPT
     {
-        return {szName, _tlgLttngType, 0, {}};
+        return lttngh_INIT_EVENT_FIELD(szName, lttngh_UstTypeFloat<sizeof(double)>::ust_type);
     }
 };
 
@@ -2049,7 +2051,7 @@ inline void _tlgCppInit1DescAuto(struct lttngh_DataDesc &desc, T const &val) _tl
 template <class T>
 inline void _tlgCppInit1DescAuto(struct lttngh_DataDesc &desc, T const &val) _tlg_NOEXCEPT
 {
-    desc = lttngh_DataDescCreate(&val, sizeof(T), lttng_alignof(T), _tlgTypeMap<T>::_tlgType);
+    desc = lttngh_DataDescCreate(&val, sizeof(T), lttngh_ALIGNOF(T), _tlgTypeMap<T>::_tlgType);
 }
 
 // The following type maps are covered by special-case overrides of _tlgCppInit1DescAuto.
@@ -2145,53 +2147,56 @@ inline void _tlgCppInit1DescAuto(struct lttngh_DataDesc &desc, wchar_t *val) _tl
 template <>
 struct _tlgTypeMapBase<char>
 {
-    static constexpr lttng_type _tlgLttngType =
-        {atype_array, {.array = {{atype_integer, {.basic = {.integer = {8u * sizeof(char), 8u * lttng_alignof(char), 0, _tlg_IntFieldType_tlgUTF8}}}}, 1}}};
-
     static const lttngh_DataType _tlgType = lttngh_DataType_Unsigned;
-    static inline constexpr lttng_event_field _tlgField(char const *szName) _tlg_NOEXCEPT
+    static inline constexpr lttngh_ust_event_field _tlgField(char const *szName) _tlg_NOEXCEPT
     {
-        return {szName, _tlgLttngType, 0, {}};
+        return lttngh_INIT_EVENT_FIELD(szName, lttngh_UstTypeUtf8Char<sizeof(char)>::ust_type);
     }
 };
 
 inline void _tlgCppInit1DescAuto(struct lttngh_DataDesc &desc, char const &val) _tlg_NOEXCEPT _tlg_INLINE_ATTRIBUTES;
 inline void _tlgCppInit1DescAuto(struct lttngh_DataDesc &desc, char const &val) _tlg_NOEXCEPT
 {
-    desc = lttngh_DataDescCreateCounted(&val, sizeof(char), lttng_alignof(char), 1);
+    desc = lttngh_DataDescCreateCounted(&val, sizeof(char), lttngh_ALIGNOF(char), 1);
 }
 
 template <>
-struct _tlgTypeMapBase<char16_t> : _tlgTypeMapUtf8Sequence
+struct _tlgTypeMapBase<char16_t> : _tlgTypeMapUtf8String
 {
 };
 
-inline void _tlgCppInit1DescAuto(struct lttngh_DataDesc &desc, char16_t const &val) _tlg_NOEXCEPT _tlg_INLINE_ATTRIBUTES;
-inline void _tlgCppInit1DescAuto(struct lttngh_DataDesc &desc, char16_t const &val) _tlg_NOEXCEPT
+inline void _tlgCppInit1DescAuto(struct lttngh_DataDesc &desc, char16_t const &val, _tlgCharBuf<char16_t>&& buf = _tlgCharBuf<char16_t>()) _tlg_NOEXCEPT _tlg_INLINE_ATTRIBUTES;
+inline void _tlgCppInit1DescAuto(struct lttngh_DataDesc &desc, char16_t const &val, _tlgCharBuf<char16_t>&& buf) _tlg_NOEXCEPT
 {
-    desc = lttngh_DataDescCreateSequenceUtf16(&val, 1);
+    buf._tlgBuf[0] = val;
+    buf._tlgBuf[1] = u'\0';
+    desc = lttngh_DataDescCreateStringUtf16(buf._tlgBuf);
 }
 
 template <>
-struct _tlgTypeMapBase<char32_t> : _tlgTypeMapUtf8Sequence
+struct _tlgTypeMapBase<char32_t> : _tlgTypeMapUtf8String
 {
 };
 
-inline void _tlgCppInit1DescAuto(struct lttngh_DataDesc &desc, char32_t const &val) _tlg_NOEXCEPT _tlg_INLINE_ATTRIBUTES;
-inline void _tlgCppInit1DescAuto(struct lttngh_DataDesc &desc, char32_t const &val) _tlg_NOEXCEPT
+inline void _tlgCppInit1DescAuto(struct lttngh_DataDesc &desc, char32_t const &val, _tlgCharBuf<char32_t>&& buf = _tlgCharBuf<char32_t>()) _tlg_NOEXCEPT _tlg_INLINE_ATTRIBUTES;
+inline void _tlgCppInit1DescAuto(struct lttngh_DataDesc &desc, char32_t const &val, _tlgCharBuf<char32_t>&& buf) _tlg_NOEXCEPT
 {
-    desc = lttngh_DataDescCreateSequenceUtf32(&val, 1);
+    buf._tlgBuf[0] = val;
+    buf._tlgBuf[1] = U'\0';
+    desc = lttngh_DataDescCreateStringUtf32(buf._tlgBuf);
 }
 
 template <>
-struct _tlgTypeMapBase<wchar_t> : _tlgTypeMapUtf8Sequence
+struct _tlgTypeMapBase<wchar_t> : _tlgTypeMapUtf8String
 {
 };
 
-inline void _tlgCppInit1DescAuto(struct lttngh_DataDesc &desc, wchar_t const &val) _tlg_NOEXCEPT _tlg_INLINE_ATTRIBUTES;
-inline void _tlgCppInit1DescAuto(struct lttngh_DataDesc &desc, wchar_t const &val) _tlg_NOEXCEPT
+inline void _tlgCppInit1DescAuto(struct lttngh_DataDesc &desc, wchar_t const &val, _tlgCharBuf<wchar_t>&& buf = _tlgCharBuf<wchar_t>()) _tlg_NOEXCEPT _tlg_INLINE_ATTRIBUTES;
+inline void _tlgCppInit1DescAuto(struct lttngh_DataDesc &desc, wchar_t const &val, _tlgCharBuf<wchar_t>&& buf) _tlg_NOEXCEPT
 {
-    desc = lttngh_DataDescCreateSequenceWchar(&val, 1);
+    buf._tlgBuf[0] = val;
+    buf._tlgBuf[1] = L'\0';
+    desc = lttngh_DataDescCreateStringWchar(buf._tlgBuf);
 }
 
 #define _tlgBeginCppEval (
@@ -2271,156 +2276,136 @@ struct _tlgIntegralEventTag : _tlgIntegralConstant<uint32_t, n>
 // FOREACH handlers
 
 #define _tlg_FieldCount(n, args) _tlg_ApplyArgs(_tlg_FieldCount, args)
+#if lttngh_UST_VER >= 213
+#define _tlg_SequenceFieldCount 2 // sequence data and length are separate fields.
+#else // lttngh_UST_VER
+#define _tlg_SequenceFieldCount 1 // sequence data and length are one field.
+#endif // lttngh_UST_VER
 #define _tlg_FieldCount_tlg_Ignored()
 #define _tlg_FieldCount_tlg_Level(eventLevel)
 #define _tlg_FieldCount_tlg_Keyword(eventKeyword)
-#define _tlg_FieldCount_tlg_Int(ctype, value, intFieldType, isSigned, ndt) +1
-#define _tlg_FieldCount_tlg_Enum(ctype, value, etype, intFieldType, isSigned, ndt) +1
-#define _tlg_FieldCount_tlg_IntArrayByRef(ctype, value, cValues, intFieldType, isSigned, ndt) +1
-#define _tlg_FieldCount_tlg_IntArray(ctype, pValues, cValues, intFieldType, isSigned, ndt) +1
-#define _tlg_FieldCount_tlg_IntFixedArray(ctype, pValues, cValues, intFieldType, isSigned, ndt) +1
-#define _tlg_FieldCount_tlg_Float(ctype, value, ndt) +1
-#define _tlg_FieldCount_tlg_FloatArray(ctype, pValues, cValues, ndt) +1
-#define _tlg_FieldCount_tlg_FloatFixedArray(ctype, pValues, cValues, ndt) +1
+#define _tlg_FieldCount_tlg_Scalar(ctype, value, scalarUstType, dataType, ndt) +1
+#define _tlg_FieldCount_tlg_ScalarByRef(ctype, value, cValues, arrayUstType, ndt) +1
+#define _tlg_FieldCount_tlg_VarArray(ctype, pValues, cValues, sequenceUstType, ndt) +_tlg_SequenceFieldCount
+#define _tlg_FieldCount_tlg_FixedArray(ctype, pValues, cValues, elementUstType, ndt) +1
 #define _tlg_FieldCount_tlg_Char8(ctype, value, ndt) +1
 #define _tlg_FieldCount_tlg_CharW(ctype, value, ndt) +1
 #define _tlg_FieldCount_tlg_CharNN(ctype, value, NN, ndt) +1
 #define _tlg_FieldCount_tlg_String8(ctype, pszValue, ndt) +1
 #define _tlg_FieldCount_tlg_StringW(ctype, pszValue, ndt) +1
 #define _tlg_FieldCount_tlg_StringNN(ctype, pszValue, NN, ndt) +1
-#define _tlg_FieldCount_tlg_CountedString8(ctype, pchValue, cchValue, ndt) +1
-#define _tlg_FieldCount_tlg_CountedStringW(ctype, pchValue, cchValue, ndt) +1
-#define _tlg_FieldCount_tlg_CountedStringNN(ctype, pchValue, cchValue, NN, ndt) +1
-#define _tlg_FieldCount_tlg_Binary(ctype, pValue, cbValue, ndt) +1
-#define _tlg_FieldCount_tlg_Sid(ctype, pValue, ndt) +1
-#define _tlg_FieldCount_tlg_GuidPtr(ctype, pValue, name) +1
-#define _tlg_FieldCount_tlg_Buffer(ctype, pValue, ndt) +1
+#define _tlg_FieldCount_tlg_CountedString8(ctype, pchValue, cchValue, ndt) +_tlg_SequenceFieldCount
+#define _tlg_FieldCount_tlg_CountedStringW(ctype, pchValue, cchValue, ndt) +_tlg_SequenceFieldCount
+#define _tlg_FieldCount_tlg_CountedStringNN(ctype, pchValue, cchValue, NN, ndt) +_tlg_SequenceFieldCount
+#define _tlg_FieldCount_tlg_Binary(ctype, pValue, cbValue, ndt) +_tlg_SequenceFieldCount
+#define _tlg_FieldCount_tlg_Sid(ctype, pValue, ndt) +_tlg_SequenceFieldCount
+#define _tlg_FieldCount_tlg_ActivityId(ctype, pValue, name) +_tlg_SequenceFieldCount
+#define _tlg_FieldCount_tlg_Buffer(ctype, pValue, ndt) +_tlg_SequenceFieldCount
 #define _tlg_FieldCount_tlg_Value(value, ndt) +1
 
-#define _tlg_FieldInfo(n, args) _tlg_ApplyArgs(_tlg_FieldInfo, args)
-#define _tlg_FieldInfo_tlg_Ignored()
-#define _tlg_FieldInfo_tlg_Level(eventLevel)
-#define _tlg_FieldInfo_tlg_Keyword(eventKeyword)
-#define _tlg_FieldInfo_tlg_Int(ctype, value, intFieldType, isSigned, ndt)                                                                 \
-    {_tlg_NDT_Name(ndt),                                                                                                                  \
-     {atype_integer, {.basic = {.integer = {8u * sizeof(ctype), 8u * lttng_alignof(ctype), isSigned, _tlg_IntFieldType##intFieldType}}}}, \
-     0,                                                                                                                                   \
-     {}},
-#define _tlg_FieldInfo_tlg_Enum(ctype, value, etype, intFieldType, isSigned, ndt)                                                                    \
-    {_tlg_NDT_Name(ndt),                                                                                                                             \
-     {atype_enum, {.basic = {.enumeration = {&etype, {8u * sizeof(ctype), 8u * lttng_alignof(ctype), isSigned, _tlg_IntFieldType##intFieldType}}}}}, \
-     0,                                                                                                                                              \
-     {}},
-#define _tlg_FieldInfo_tlg_IntArrayByRef(ctype, value, cValues, intFieldType, isSigned, ndt)                                                                                     \
-    {_tlg_NDT_Name(ndt),                                                                                                                                                         \
-     {atype_array, {.array = {{atype_integer, {.basic = {.integer = {8u * sizeof(ctype), 8u * lttng_alignof(ctype), isSigned, _tlg_IntFieldType##intFieldType}}}}, (cValues)}}}, \
-     0,                                                                                                                                                                          \
-     {}},
-#define _tlg_FieldInfo_tlg_IntArray(ctype, pValues, cValues, intFieldType, isSigned, ndt)                                                                                                                                                                                                                    \
-    {_tlg_NDT_Name(ndt),                                                                                                                                                                                                                                                                                     \
-     {atype_sequence, {.sequence = {{atype_integer, {.basic = {.integer = {8u * sizeof(uint16_t), 8u * lttng_alignof(uint16_t), 0, _tlg_IntFieldType_tlgDecimal}}}}, {atype_integer, {.basic = {.integer = {8u * sizeof(ctype), 8u * lttng_alignof(ctype), isSigned, _tlg_IntFieldType##intFieldType}}}}}}}, \
-     0,                                                                                                                                                                                                                                                                                                      \
-     {}},
-#define _tlg_FieldInfo_tlg_IntFixedArray(ctype, pValues, cValues, intFieldType, isSigned, ndt)                                                                                   \
-    {_tlg_NDT_Name(ndt),                                                                                                                                                         \
-     {atype_array, {.array = {{atype_integer, {.basic = {.integer = {8u * sizeof(ctype), 8u * lttng_alignof(ctype), isSigned, _tlg_IntFieldType##intFieldType}}}}, (cValues)}}}, \
-     0,                                                                                                                                                                          \
-     {}},
-#define _tlg_FieldInfo_tlg_Float(ctype, value, ndt)                       \
-    {_tlg_NDT_Name(ndt),                                                  \
-     {atype_float, {.basic = {._float = {_tlg_FloatFieldType_##ctype}}}}, \
-     0,                                                                   \
-     {}},
-#define _tlg_FieldInfo_tlg_FloatArray(ctype, pValues, cValues, ndt)                                                                                                                                                                          \
-    {_tlg_NDT_Name(ndt),                                                                                                                                                                                                                     \
-     {atype_sequence, {.sequence = {{atype_integer, {.basic = {.integer = {8u * sizeof(uint16_t), 8u * lttng_alignof(uint16_t), 0, _tlg_IntFieldType_tlgDecimal}}}}, {atype_float, {.basic = {._float = {_tlg_FloatFieldType_##ctype}}}}}}}, \
-     0,                                                                                                                                                                                                                                      \
-     {}},
-#define _tlg_FieldInfo_tlg_FloatFixedArray(ctype, pValues, cValues, ndt)                                         \
-    {_tlg_NDT_Name(ndt),                                                                                         \
-     {atype_array, {.array = {{atype_float, {.basic = {._float = {_tlg_FloatFieldType_##ctype}}}}, (cValues)}}}, \
-     0,                                                                                                          \
-     {}},
-#define _tlg_FieldInfo_tlg_Char8(ctype, value, ndt)                                                                                                         \
-    {_tlg_NDT_Name(ndt),                                                                                                                                    \
-     {atype_array, {.array = {{atype_integer, {.basic = {.integer = {8u * sizeof(ctype), 8u * lttng_alignof(ctype), 0, _tlg_IntFieldType_tlgUTF8}}}}, 1}}}, \
-     0,                                                                                                                                                     \
-     {}},
-#define _tlg_FieldInfo_tlg_CharW(ctype, value, ndt)                                                                                                                                                                                                                                           \
-    {_tlg_NDT_Name(ndt),                                                                                                                                                                                                                                                                      \
-     {atype_sequence, {.sequence = {{atype_integer, {.basic = {.integer = {8u * sizeof(uint16_t), 8u * lttng_alignof(uint16_t), 0, _tlg_IntFieldType_tlgDecimal}}}}, {atype_integer, {.basic = {.integer = {8u * sizeof(char), 8u * lttng_alignof(char), 0, _tlg_IntFieldType_tlgUTF8}}}}}}}, \
-     0,                                                                                                                                                                                                                                                                                       \
-     {}},
-#define _tlg_FieldInfo_tlg_CharNN(ctype, value, NN, ndt)                                                                                                                                                                                                                                      \
-    {_tlg_NDT_Name(ndt),                                                                                                                                                                                                                                                                      \
-     {atype_sequence, {.sequence = {{atype_integer, {.basic = {.integer = {8u * sizeof(uint16_t), 8u * lttng_alignof(uint16_t), 0, _tlg_IntFieldType_tlgDecimal}}}}, {atype_integer, {.basic = {.integer = {8u * sizeof(char), 8u * lttng_alignof(char), 0, _tlg_IntFieldType_tlgUTF8}}}}}}}, \
-     0,                                                                                                                                                                                                                                                                                       \
-     {}},
-#define _tlg_FieldInfo_tlg_String8(ctype, pszValue, ndt)         \
-    {_tlg_NDT_Name(ndt),                                         \
-     {atype_string, {.basic = {.string = {lttng_encode_UTF8}}}}, \
-     0,                                                          \
-     {}},
-#define _tlg_FieldInfo_tlg_StringW(ctype, pszValue, ndt)         \
-    {_tlg_NDT_Name(ndt),                                         \
-     {atype_string, {.basic = {.string = {lttng_encode_UTF8}}}}, \
-     0,                                                          \
-     {}},
-#define _tlg_FieldInfo_tlg_StringNN(ctype, pszValue, NN, ndt)    \
-    {_tlg_NDT_Name(ndt),                                         \
-     {atype_string, {.basic = {.string = {lttng_encode_UTF8}}}}, \
-     0,                                                          \
-     {}},
-#define _tlg_FieldInfo_tlg_CountedString8(ctype, pchValue, cchValue, ndt)                                                                                                                                                                                                                       \
-    {_tlg_NDT_Name(ndt),                                                                                                                                                                                                                                                                        \
-     {atype_sequence, {.sequence = {{atype_integer, {.basic = {.integer = {8u * sizeof(uint16_t), 8u * lttng_alignof(uint16_t), 0, _tlg_IntFieldType_tlgDecimal}}}}, {atype_integer, {.basic = {.integer = {8u * sizeof(ctype), 8u * lttng_alignof(ctype), 0, _tlg_IntFieldType_tlgUTF8}}}}}}}, \
-     0,                                                                                                                                                                                                                                                                                         \
-     {}},
-#define _tlg_FieldInfo_tlg_CountedStringW(ctype, pchValue, cchValue, ndt)                                                                                                                                                                                                                     \
-    {_tlg_NDT_Name(ndt),                                                                                                                                                                                                                                                                      \
-     {atype_sequence, {.sequence = {{atype_integer, {.basic = {.integer = {8u * sizeof(uint16_t), 8u * lttng_alignof(uint16_t), 0, _tlg_IntFieldType_tlgDecimal}}}}, {atype_integer, {.basic = {.integer = {8u * sizeof(char), 8u * lttng_alignof(char), 0, _tlg_IntFieldType_tlgUTF8}}}}}}}, \
-     0,                                                                                                                                                                                                                                                                                       \
-     {}},
-#define _tlg_FieldInfo_tlg_CountedStringNN(ctype, pchValue, cchValue, NN, ndt)                                                                                                                                                                                                                \
-    {_tlg_NDT_Name(ndt),                                                                                                                                                                                                                                                                      \
-     {atype_sequence, {.sequence = {{atype_integer, {.basic = {.integer = {8u * sizeof(uint16_t), 8u * lttng_alignof(uint16_t), 0, _tlg_IntFieldType_tlgDecimal}}}}, {atype_integer, {.basic = {.integer = {8u * sizeof(char), 8u * lttng_alignof(char), 0, _tlg_IntFieldType_tlgUTF8}}}}}}}, \
-     0,                                                                                                                                                                                                                                                                                       \
-     {}},
-#define _tlg_FieldInfo_tlg_Binary(ctype, pValue, cbValue, ndt)                                                                                                                                                                                                                                     \
-    {_tlg_NDT_Name(ndt),                                                                                                                                                                                                                                                                           \
-     {atype_sequence, {.sequence = {{atype_integer, {.basic = {.integer = {8u * sizeof(uint16_t), 8u * lttng_alignof(uint16_t), 0, _tlg_IntFieldType_tlgDecimal}}}}, {atype_integer, {.basic = {.integer = {8u * sizeof(uint8_t), 8u * lttng_alignof(uint8_t), 0, _tlg_IntFieldType_tlgHex}}}}}}}, \
-     0,                                                                                                                                                                                                                                                                                            \
-     {}},
-#define _tlg_FieldInfo_tlg_Sid(ctype, pValue, ndt)                                                                                                                                                                                                                                                 \
-    {_tlg_NDT_Name(ndt),                                                                                                                                                                                                                                                                           \
-     {atype_sequence, {.sequence = {{atype_integer, {.basic = {.integer = {8u * sizeof(uint16_t), 8u * lttng_alignof(uint16_t), 0, _tlg_IntFieldType_tlgDecimal}}}}, {atype_integer, {.basic = {.integer = {8u * sizeof(uint8_t), 8u * lttng_alignof(uint8_t), 0, _tlg_IntFieldType_tlgHex}}}}}}}, \
-     0,                                                                                                                                                                                                                                                                                            \
-     {}},
-#define _tlg_FieldInfo_tlg_GuidPtr(ctype, pValue, name)                                                                                                                                                                                                                                          \
-    {name,                                                                                                                                                                                                                                                                                       \
-     {atype_sequence, {.sequence = {{atype_integer, {.basic = {.integer = {8u * sizeof(uint8_t), 8u * lttng_alignof(uint8_t), 0, _tlg_IntFieldType_tlgDecimal}}}}, {atype_integer, {.basic = {.integer = {8u * sizeof(uint8_t), 8u * lttng_alignof(uint8_t), 0, _tlg_IntFieldType_tlgHex}}}}}}}, \
-     0,                                                                                                                                                                                                                                                                                          \
-     {}},
-#define _tlg_FieldInfo_tlg_Buffer(ctype, pValue, ndt)                                                                                                                                                                                                                                              \
-    {_tlg_NDT_Name(ndt),                                                                                                                                                                                                                                                                           \
-     {atype_sequence, {.sequence = {{atype_integer, {.basic = {.integer = {8u * sizeof(uint16_t), 8u * lttng_alignof(uint16_t), 0, _tlg_IntFieldType_tlgDecimal}}}}, {atype_integer, {.basic = {.integer = {8u * sizeof(uint8_t), 8u * lttng_alignof(uint8_t), 0, _tlg_IntFieldType_tlgHex}}}}}}}, \
-     0,                                                                                                                                                                                                                                                                                            \
-     {}},
-#define _tlg_FieldInfo_tlg_Value(value, ndt) \
-    _tlgTypeMap<decltype(value)>::_tlgField(_tlg_NDT_Name(ndt)),
+#define _tlg_EventField(n, args) _tlg_ApplyArgsN(_tlg_EventField, n, args)
+#if lttngh_UST_VER >= 213
+#define _tlg_INIT_SCALAR_FIELD(n, name, scalarUstType) \
+    static lttngh_ust_event_field const _tlg_field##n = \
+        lttngh_INIT_EVENT_FIELD(name, _tlg_ApplyUnwrap scalarUstType);
+#define _tlg_INIT_VALUE_FIELD(n, name, value) \
+    static lttngh_ust_event_field const _tlg_field##n = \
+        _tlgTypeMap<decltype(value)>::_tlgField(name);
+#define _tlg_INIT_SEQUENCE_FIELDS(n, name, countUstType, sequenceUstType) \
+    static lttngh_ust_event_field const _tlg_field##n##Len = \
+        lttngh_INIT_EVENT_FIELD("_" name "_length", _tlg_ApplyUnwrap countUstType); \
+    static lttngh_ust_event_field const _tlg_field##n = \
+        lttngh_INIT_EVENT_FIELD(name, _tlg_ApplyUnwrap sequenceUstType);
+#define _tlg_INIT_ARRAY_FIELD(n, name, cValues, elementCType, elementUstType) \
+    static struct lttng_ust_type_array const _tlg_FieldType##n = \
+        lttngh_INIT_TYPE_ARRAY(elementUstType, cValues, lttngh_ALIGNOF(elementCType)); \
+    static lttngh_ust_event_field const _tlg_field##n = \
+        lttngh_INIT_EVENT_FIELD(name, _tlg_FieldType##n);
+#else // lttngh_UST_VER
+#define _tlg_INIT_SCALAR_FIELD(n, name, scalarUstType) \
+    lttngh_INIT_EVENT_FIELD(name, _tlg_ApplyUnwrap scalarUstType),
+#define _tlg_INIT_VALUE_FIELD(n, name, value) \
+    _tlgTypeMap<decltype(value)>::_tlgField(name),
+#define _tlg_INIT_SEQUENCE_FIELDS(n, name, countUstType, sequenceUstType) \
+    lttngh_INIT_EVENT_FIELD(name, _tlg_ApplyUnwrap sequenceUstType),
+#define _tlg_INIT_ARRAY_FIELD(n, name, cValues, elementCType, elementUstType) \
+    lttngh_INIT_EVENT_FIELD(name, lttngh_INIT_TYPE_ARRAY(_tlg_ApplyUnwrap elementUstType, cValues, lttngh_ALIGNOF(elementCType))),
+#endif // lttngh_UST_VER
+#define _tlg_EventField_tlg_Ignored(n, ...)
+#define _tlg_EventField_tlg_Level(  n, eventLevel)
+#define _tlg_EventField_tlg_Keyword(n, eventKeyword)
+#define _tlg_EventField_tlg_Scalar( n, ctype, value, scalarUstType, dataType, ndt) \
+    _tlg_INIT_SCALAR_FIELD(n, _tlg_NDT_Name(ndt), scalarUstType)
+#define _tlg_EventField_tlg_ScalarByRef(n, ctype, value, cValues, arrayUstType, ndt) \
+    _tlg_INIT_SCALAR_FIELD(n, _tlg_NDT_Name(ndt), arrayUstType)
+#define _tlg_EventField_tlg_VarArray(n, ctype, pValues, cValues, sequenceUstType, ndt) \
+    _tlg_INIT_SEQUENCE_FIELDS(n, _tlg_NDT_Name(ndt), (lttngh_TypeUInt16), sequenceUstType)
+#define _tlg_EventField_tlg_FixedArray(n, ctype, pValues, cValues, elementUstType, ndt) \
+    _tlg_INIT_ARRAY_FIELD(n, _tlg_NDT_Name(ndt), cValues, ctype, elementUstType)
+#define _tlg_EventField_tlg_Char8(n, ctype, value, ndt) \
+    _tlg_INIT_SCALAR_FIELD(n, _tlg_NDT_Name(ndt), (lttngh_TypeUtf8Char))
+#define _tlg_EventField_tlg_CharW(n, ctype, value, ndt) \
+    _tlg_INIT_SCALAR_FIELD(n, _tlg_NDT_Name(ndt), (lttngh_TypeUtf8String))
+#define _tlg_EventField_tlg_CharNN(n, ctype, value, NN, ndt) \
+    _tlg_INIT_SCALAR_FIELD(n, _tlg_NDT_Name(ndt), (lttngh_TypeUtf8String))
+#define _tlg_EventField_tlg_String8(n, ctype, pszValue, ndt) \
+    _tlg_INIT_SCALAR_FIELD(n, _tlg_NDT_Name(ndt), (lttngh_TypeUtf8String))
+#define _tlg_EventField_tlg_StringW(n, ctype, pszValue, ndt) \
+    _tlg_INIT_SCALAR_FIELD(n, _tlg_NDT_Name(ndt), (lttngh_TypeUtf8String))
+#define _tlg_EventField_tlg_StringNN(n, ctype, pszValue, NN, ndt) \
+    _tlg_INIT_SCALAR_FIELD(n, _tlg_NDT_Name(ndt), (lttngh_TypeUtf8String))
+#define _tlg_EventField_tlg_CountedString8(n, ctype, pchValue, cchValue, ndt) \
+    _tlg_INIT_SEQUENCE_FIELDS(n, _tlg_NDT_Name(ndt), (lttngh_TypeUInt16), (lttngh_TypeUtf8Sequence))
+#define _tlg_EventField_tlg_CountedStringW(n, ctype, pchValue, cchValue, ndt) \
+    _tlg_INIT_SEQUENCE_FIELDS(n, _tlg_NDT_Name(ndt), (lttngh_TypeUInt16), (lttngh_TypeUtf8Sequence))
+#define _tlg_EventField_tlg_CountedStringNN(n, ctype, pchValue, cchValue, NN, ndt) \
+    _tlg_INIT_SEQUENCE_FIELDS(n, _tlg_NDT_Name(ndt), (lttngh_TypeUInt16), (lttngh_TypeUtf8Sequence))
+#define _tlg_EventField_tlg_Binary(n, ctype, pValue, cbValue, ndt) \
+    _tlg_INIT_SEQUENCE_FIELDS(n, _tlg_NDT_Name(ndt), (lttngh_TypeUInt16), (lttngh_TypeHexInt8Sequence))
+#define _tlg_EventField_tlg_Sid(n, ctype, pValue, ndt) \
+    _tlg_INIT_SEQUENCE_FIELDS(n, _tlg_NDT_Name(ndt), (lttngh_TypeUInt16), (lttngh_TypeHexInt8Sequence))
+#define _tlg_EventField_tlg_ActivityId(n, ctype, pValue, name) \
+    _tlg_INIT_SEQUENCE_FIELDS(n, name, (lttngh_TypeUInt8), (lttngh_TypeActivityId)) // NOTE: length field is 8-bit.
+#define _tlg_EventField_tlg_Buffer(n, ctype, pValue, ndt) \
+    _tlg_INIT_SEQUENCE_FIELDS(n, _tlg_NDT_Name(ndt), (lttngh_TypeUInt16), (lttngh_TypeHexInt8Sequence))
+#define _tlg_EventField_tlg_Value(n, value, ndt) \
+    _tlg_INIT_VALUE_FIELD(n, _tlg_NDT_Name(ndt), value)
+
+#if lttngh_UST_VER >= 213
+#define _tlg_EventFieldRef(n, args) _tlg_ApplyArgsN(_tlg_EventFieldRef, n, args)
+#define _tlg_EventFieldRefNormal(n)   &_tlg_field##n,
+#define _tlg_EventFieldRefSequence(n) &_tlg_field##n##Len, &_tlg_field##n,
+#define _tlg_EventFieldRef_tlg_Ignored(n, ...)
+#define _tlg_EventFieldRef_tlg_Level(n, eventLevel)
+#define _tlg_EventFieldRef_tlg_Keyword(n, eventKeyword)
+#define _tlg_EventFieldRef_tlg_Scalar(n, ctype, value, scalarUstType, dataType, ndt)        _tlg_EventFieldRefNormal(n)
+#define _tlg_EventFieldRef_tlg_ScalarByRef(n, ctype, value, cValues, arrayUstType, ndt)     _tlg_EventFieldRefNormal(n)
+#define _tlg_EventFieldRef_tlg_VarArray(n, ctype, pValues, cValues, sequenceUstType, ndt)   _tlg_EventFieldRefSequence(n)
+#define _tlg_EventFieldRef_tlg_FixedArray(n, ctype, pValues, cValues, elementUstType, ndt)  _tlg_EventFieldRefNormal(n)
+#define _tlg_EventFieldRef_tlg_Char8(n, ctype, value, ndt)                                  _tlg_EventFieldRefNormal(n)
+#define _tlg_EventFieldRef_tlg_CharW(n, ctype, value, ndt)                                  _tlg_EventFieldRefNormal(n)
+#define _tlg_EventFieldRef_tlg_CharNN(n, ctype, value, NN, ndt)                             _tlg_EventFieldRefNormal(n)
+#define _tlg_EventFieldRef_tlg_String8(n, ctype, pszValue, ndt)                             _tlg_EventFieldRefNormal(n)
+#define _tlg_EventFieldRef_tlg_StringW(n, ctype, pszValue, ndt)                             _tlg_EventFieldRefNormal(n)
+#define _tlg_EventFieldRef_tlg_StringNN(n, ctype, pszValue, NN, ndt)                        _tlg_EventFieldRefNormal(n)
+#define _tlg_EventFieldRef_tlg_CountedString8(n, ctype, pchValue, cchValue, ndt)            _tlg_EventFieldRefSequence(n)
+#define _tlg_EventFieldRef_tlg_CountedStringW(n, ctype, pchValue, cchValue, ndt)            _tlg_EventFieldRefSequence(n)
+#define _tlg_EventFieldRef_tlg_CountedStringNN(n, ctype, pchValue, cchValue, NN, ndt)       _tlg_EventFieldRefSequence(n)
+#define _tlg_EventFieldRef_tlg_Binary(n, ctype, pValue, cbValue, ndt)                       _tlg_EventFieldRefSequence(n)
+#define _tlg_EventFieldRef_tlg_Sid(n, ctype, pValue, ndt)                                   _tlg_EventFieldRefSequence(n)
+#define _tlg_EventFieldRef_tlg_ActivityId(n, ctype, pValue, name)                           _tlg_EventFieldRefSequence(n)
+#define _tlg_EventFieldRef_tlg_Buffer(n, ctype, pValue, ndt)                                _tlg_EventFieldRefSequence(n)
+#define _tlg_EventFieldRef_tlg_Value(n, value, ndt)                                         _tlg_EventFieldRefNormal(n)
+#endif // lttngh_UST_VER
 
 #define _tlg_LevelVal(n, args) _tlg_ApplyArgs(_tlg_LevelVal, args)
 #define _tlg_LevelVal_tlg_Ignored()
 #define _tlg_LevelVal_tlg_Level(eventLevel) &0 )|( _tlg_ENSURE_CONST(Level, eventLevel)
 #define _tlg_LevelVal_tlg_Keyword(eventKeyword)
-#define _tlg_LevelVal_tlg_Int(ctype, value, intFieldType, isSigned, ndt)
-#define _tlg_LevelVal_tlg_Enum(ctype, value, etype, intFieldType, isSigned, ndt)
-#define _tlg_LevelVal_tlg_IntArrayByRef(ctype, value, cValues, intFieldType, isSigned, ndt)
-#define _tlg_LevelVal_tlg_IntArray(ctype, pValues, cValues, intFieldType, isSigned, ndt)
-#define _tlg_LevelVal_tlg_IntFixedArray(ctype, pValues, cValues, intFieldType, isSigned, ndt)
-#define _tlg_LevelVal_tlg_Float(ctype, value, ndt)
-#define _tlg_LevelVal_tlg_FloatArray(ctype, pValues, cValues, ndt)
-#define _tlg_LevelVal_tlg_FloatFixedArray(ctype, pValues, cValues, ndt)
+#define _tlg_LevelVal_tlg_Scalar(ctype, value, scalarUstType, dataType, ndt)
+#define _tlg_LevelVal_tlg_ScalarByRef(ctype, value, cValues, arrayUstType, ndt)
+#define _tlg_LevelVal_tlg_VarArray(ctype, pValues, cValues, sequenceUstType, ndt)
+#define _tlg_LevelVal_tlg_FixedArray(ctype, pValues, cValues, elementUstType, ndt)
 #define _tlg_LevelVal_tlg_Char8(ctype, value, ndt)
 #define _tlg_LevelVal_tlg_CharW(ctype, value, ndt)
 #define _tlg_LevelVal_tlg_CharNN(ctype, value, NN, ndt)
@@ -2432,7 +2417,7 @@ struct _tlgIntegralEventTag : _tlgIntegralConstant<uint32_t, n>
 #define _tlg_LevelVal_tlg_CountedStringNN(ctype, pchValue, cchValue, NN, ndt)
 #define _tlg_LevelVal_tlg_Binary(ctype, pValue, cbValue, ndt)
 #define _tlg_LevelVal_tlg_Sid(ctype, pValue, ndt)
-#define _tlg_LevelVal_tlg_GuidPtr(ctype, pValue, name)
+#define _tlg_LevelVal_tlg_ActivityId(ctype, pValue, name)
 #define _tlg_LevelVal_tlg_Buffer(ctype, pValue, ndt)
 #define _tlg_LevelVal_tlg_Value(value, ndt)
 
@@ -2440,14 +2425,10 @@ struct _tlgIntegralEventTag : _tlgIntegralConstant<uint32_t, n>
 #define _tlg_KeywordVal_tlg_Ignored()
 #define _tlg_KeywordVal_tlg_Level(eventLevel)
 #define _tlg_KeywordVal_tlg_Keyword(eventKeyword) | _tlg_ENSURE_CONST(Keyword, eventKeyword)
-#define _tlg_KeywordVal_tlg_Int(ctype, value, intFieldType, isSigned, ndt)
-#define _tlg_KeywordVal_tlg_Enum(ctype, value, etype, intFieldType, isSigned, ndt)
-#define _tlg_KeywordVal_tlg_IntArrayByRef(ctype, value, cValues, intFieldType, isSigned, ndt)
-#define _tlg_KeywordVal_tlg_IntArray(ctype, pValues, cValues, intFieldType, isSigned, ndt)
-#define _tlg_KeywordVal_tlg_IntFixedArray(ctype, pValues, cValues, intFieldType, isSigned, ndt)
-#define _tlg_KeywordVal_tlg_Float(ctype, value, ndt)
-#define _tlg_KeywordVal_tlg_FloatArray(ctype, pValues, cValues, ndt)
-#define _tlg_KeywordVal_tlg_FloatFixedArray(ctype, pValues, cValues, ndt)
+#define _tlg_KeywordVal_tlg_Scalar(ctype, value, scalarUstType, dataType, ndt)
+#define _tlg_KeywordVal_tlg_ScalarByRef(ctype, value, cValues, arrayUstType, ndt)
+#define _tlg_KeywordVal_tlg_VarArray(ctype, pValues, cValues, sequenceUstType, ndt)
+#define _tlg_KeywordVal_tlg_FixedArray(ctype, pValues, cValues, elementUstType, ndt)
 #define _tlg_KeywordVal_tlg_Char8(ctype, value, ndt)
 #define _tlg_KeywordVal_tlg_CharW(ctype, value, ndt)
 #define _tlg_KeywordVal_tlg_CharNN(ctype, value, NN, ndt)
@@ -2459,7 +2440,7 @@ struct _tlgIntegralEventTag : _tlgIntegralConstant<uint32_t, n>
 #define _tlg_KeywordVal_tlg_CountedStringNN(ctype, pchValue, cchValue, NN, ndt)
 #define _tlg_KeywordVal_tlg_Binary(ctype, pValue, cbValue, ndt)
 #define _tlg_KeywordVal_tlg_Sid(ctype, pValue, ndt)
-#define _tlg_KeywordVal_tlg_GuidPtr(ctype, pValue, name)
+#define _tlg_KeywordVal_tlg_ActivityId(ctype, pValue, name)
 #define _tlg_KeywordVal_tlg_Buffer(ctype, pValue, ndt)
 #define _tlg_KeywordVal_tlg_Value(value, ndt)
 
@@ -2467,17 +2448,13 @@ struct _tlgIntegralEventTag : _tlgIntegralConstant<uint32_t, n>
 #define _tlg_DataDescCount_tlg_Ignored()
 #define _tlg_DataDescCount_tlg_Level(eventLevel)
 #define _tlg_DataDescCount_tlg_Keyword(eventKeyword)
-#define _tlg_DataDescCount_tlg_Int(ctype, value, intFieldType, isSigned, ndt) +1
-#define _tlg_DataDescCount_tlg_Enum(ctype, value, etype, intFieldType, isSigned, ndt) +1
-#define _tlg_DataDescCount_tlg_IntArrayByRef(ctype, value, cValues, intFieldType, isSigned, ndt) +1
-#define _tlg_DataDescCount_tlg_IntArray(ctype, pValues, cValues, intFieldType, isSigned, ndt) +2 // sequence
-#define _tlg_DataDescCount_tlg_IntFixedArray(ctype, pValues, cValues, intFieldType, isSigned, ndt) +1
-#define _tlg_DataDescCount_tlg_Float(ctype, value, ndt) +1
-#define _tlg_DataDescCount_tlg_FloatArray(ctype, pValues, cValues, ndt) +2 // sequence
-#define _tlg_DataDescCount_tlg_FloatFixedArray(ctype, pValues, cValues, ndt) +1
+#define _tlg_DataDescCount_tlg_Scalar(ctype, value, scalarUstType, dataType, ndt) +1
+#define _tlg_DataDescCount_tlg_ScalarByRef(ctype, value, cValues, arrayUstType, ndt) +1
+#define _tlg_DataDescCount_tlg_VarArray(ctype, pValues, cValues, sequenceUstType, ndt) +2 // sequence
+#define _tlg_DataDescCount_tlg_FixedArray(ctype, pValues, cValues, elementUstType, ndt) +1
 #define _tlg_DataDescCount_tlg_Char8(ctype, value, ndt) +1
-#define _tlg_DataDescCount_tlg_CharW(ctype, value, ndt) +1      // sequence (transcoded)
-#define _tlg_DataDescCount_tlg_CharNN(ctype, value, NN, ndt) +1 // sequence (transcoded)
+#define _tlg_DataDescCount_tlg_CharW(ctype, value, ndt) +1
+#define _tlg_DataDescCount_tlg_CharNN(ctype, value, NN, ndt) +1
 #define _tlg_DataDescCount_tlg_String8(ctype, pszValue, ndt) +1
 #define _tlg_DataDescCount_tlg_StringW(ctype, pszValue, ndt) +1
 #define _tlg_DataDescCount_tlg_StringNN(ctype, pszValue, NN, ndt) +1
@@ -2486,7 +2463,7 @@ struct _tlgIntegralEventTag : _tlgIntegralConstant<uint32_t, n>
 #define _tlg_DataDescCount_tlg_CountedStringNN(ctype, pchValue, cchValue, NN, ndt) +1 // sequence (transcoded)
 #define _tlg_DataDescCount_tlg_Binary(ctype, pValue, cbValue, ndt) +2                 // sequence
 #define _tlg_DataDescCount_tlg_Sid(ctype, pValue, ndt) +2                             // sequence
-#define _tlg_DataDescCount_tlg_GuidPtr(ctype, pValue, name) +2                        // sequence
+#define _tlg_DataDescCount_tlg_ActivityId(ctype, pValue, name) +2                     // sequence
 #define _tlg_DataDescCount_tlg_Buffer(ctype, pValue, ndt) +2                          // sequence
 #define _tlg_DataDescCount_tlg_Value(value, ndt) +1
 
@@ -2530,23 +2507,14 @@ ctype const*)).
 #define _tlg_DataDescCreate_tlg_Ignored(...)
 #define _tlg_DataDescCreate_tlg_Level(eventLevel)
 #define _tlg_DataDescCreate_tlg_Keyword(eventKeyword)
-#define _tlg_DataDescCreate_tlg_Int(ctype, value, intFieldType, isSigned, ndt) \
-    _tlgCppInit1Desc<ctype>(_tlg_data[_tlg_idx++], (value), _tlg_IntDataSigned##isSigned),
-#define _tlg_DataDescCreate_tlg_Enum(ctype, value, etype, intFieldType, isSigned, ndt) \
-    _tlgCppInit1Desc<ctype>(_tlg_data[_tlg_idx++], (value), _tlg_IntDataSigned##isSigned),
-#define _tlg_DataDescCreate_tlg_IntArrayByRef(ctype, value, cValues, intFieldType, isSigned, ndt) \
+#define _tlg_DataDescCreate_tlg_Scalar(ctype, value, scalarUstType, dataType, ndt) \
+    _tlgCppInit1Desc<ctype>(_tlg_data[_tlg_idx++], (value), lttngh_DataType_##dataType),
+#define _tlg_DataDescCreate_tlg_ScalarByRef(ctype, value, cValues, arrayUstType, ndt) \
     _tlgCppInit1DescByRef<ctype, (cValues)>(_tlg_data[_tlg_idx++], (value)),
-#define _tlg_DataDescCreate_tlg_IntArray(ctype, pValues, cValues, intFieldType, isSigned, ndt) \
+#define _tlg_DataDescCreate_tlg_VarArray(ctype, pValues, cValues, sequenceUstType, ndt) \
     _tlgCppInit2DescArray<ctype>(&_tlg_data[_tlg_idx], (pValues), (cValues)),                  \
     _tlg_idx += 2,
-#define _tlg_DataDescCreate_tlg_IntFixedArray(ctype, pValues, cValues, intFieldType, isSigned, ndt) \
-    _tlgCppInit1DescFixedArray<ctype, (cValues)>(_tlg_data[_tlg_idx++], (pValues)),
-#define _tlg_DataDescCreate_tlg_Float(ctype, value, ndt) \
-    _tlgCppInit1Desc<ctype>(_tlg_data[_tlg_idx++], (value), lttngh_DataType_Float),
-#define _tlg_DataDescCreate_tlg_FloatArray(ctype, pValues, cValues, ndt)      \
-    _tlgCppInit2DescArray<ctype>(&_tlg_data[_tlg_idx], (pValues), (cValues)), \
-    _tlg_idx += 2,
-#define _tlg_DataDescCreate_tlg_FloatFixedArray(ctype, pValues, cValues, ndt) \
+#define _tlg_DataDescCreate_tlg_FixedArray(ctype, pValues, cValues, elementUstType, ndt) \
     _tlgCppInit1DescFixedArray<ctype, (cValues)>(_tlg_data[_tlg_idx++], (pValues)),
 #define _tlg_DataDescCreate_tlg_Char8(ctype, value, ndt) \
     _tlgCppInit1DescByRef<ctype, 1, ctype>(_tlg_data[_tlg_idx++], (value)),
@@ -2568,59 +2536,48 @@ ctype const*)).
 #define _tlg_DataDescCreate_tlg_CountedStringNN(ctype, pchValue, cchValue, NN, ndt) \
     _tlgCppInit1DescSeqUtf##NN<ctype>(_tlg_data[_tlg_idx++], (pchValue), (cchValue)),
 #define _tlg_DataDescCreate_tlg_Binary(ctype, pValue, cbValue, ndt)                                                   \
-    _tlgCppInit2DescArray<ctype, sizeof(uint8_t), lttng_alignof(uint8_t)>(&_tlg_data[_tlg_idx], (pValue), (cbValue)), \
+    _tlgCppInit2DescArray<ctype, sizeof(uint8_t), lttngh_ALIGNOF(uint8_t)>(&_tlg_data[_tlg_idx], (pValue), (cbValue)), \
     _tlg_idx += 2,
 #define _tlg_DataDescCreate_tlg_Sid(ctype, pValue, ndt)         \
     _tlgCppInit2DescSid<ctype>(&_tlg_data[_tlg_idx], (pValue)), \
     _tlg_idx += 2,
-#define _tlg_DataDescCreate_tlg_GuidPtr(ctype, pValue, name)        \
-    _tlgCppInit2DescGuidPtr<ctype>(&_tlg_data[_tlg_idx], (pValue)), \
+#define _tlg_DataDescCreate_tlg_ActivityId(ctype, pValue, name)        \
+    _tlgCppInit2DescActivityId<ctype>(&_tlg_data[_tlg_idx], (pValue)), \
     _tlg_idx += 2,
 #define _tlg_DataDescCreate_tlg_Buffer(ctype, pValue, ndt)         \
     _tlgCppInit2DescBuffer<ctype>(&_tlg_data[_tlg_idx], (pValue)), \
     _tlg_idx += 2,
 #define _tlg_DataDescCreate_tlg_Value(value, ndt) \
     _tlgCppInit1DescAuto(_tlg_data[_tlg_idx++], (value)),
+
 #else // __cplusplus
+
 // C implementation of DataDescCreate:
 #define _tlg_DataDescCreate(n, args) _tlg_ApplyArgsN(_tlg_DataDescCreate, n, args)
 #define _tlg_DataDescCreate_tlg_Ignored(n, ...)
 #define _tlg_DataDescCreate_tlg_Level(n, eventLevel)
 #define _tlg_DataDescCreate_tlg_Keyword(n, eventKeyword)
-#define _tlg_DataDescCreate_tlg_Int(n, ctype, value, intFieldType, isSigned, ndt) \
+#define _tlg_DataDescCreate_tlg_Scalar(n, ctype, value, scalarUstType, dataType, ndt) \
     ctype const _tlg_temp##n = (value);                                           \
-    _tlg_data[_tlg_idx++] = lttngh_DataDescCreate(&_tlg_temp##n, sizeof(ctype), lttng_alignof(ctype), _tlg_IntDataSigned##isSigned);
-#define _tlg_DataDescCreate_tlg_Enum(n, ctype, value, etype, intFieldType, isSigned, ndt) \
-    ctype const _tlg_temp##n = (value);                                                   \
-    _tlg_data[_tlg_idx++] = lttngh_DataDescCreate(&_tlg_temp##n, sizeof(ctype), lttng_alignof(ctype), _tlg_IntDataSigned##isSigned);
-#define _tlg_DataDescCreate_tlg_IntArrayByRef(n, ctype, value, cValues, intFieldType, isSigned, ndt) \
-    _tlg_data[_tlg_idx++] = lttngh_DataDescCreateCounted(&(value), (cValues) * sizeof(ctype), lttng_alignof(ctype), (cValues));
-#define _tlg_DataDescCreate_tlg_IntArray(n, ctype, pValues, cValues, intFieldType, isSigned, ndt)                 \
+    _tlg_data[_tlg_idx++] = lttngh_DataDescCreate(&_tlg_temp##n, sizeof(ctype), lttngh_ALIGNOF(ctype), lttngh_DataType_##dataType);
+#define _tlg_DataDescCreate_tlg_ScalarByRef(n, ctype, value, cValues, arrayUstType, ndt) \
+    _tlg_data[_tlg_idx++] = lttngh_DataDescCreateCounted(&(value), (cValues) * sizeof(ctype), lttngh_ALIGNOF(ctype), (cValues));
+#define _tlg_DataDescCreate_tlg_VarArray(n, ctype, pValues, cValues, sequenceUstType, ndt)                 \
     ctype const *const _tlg_temp##n = (pValues);                                                                  \
-    _tlg_DataDescCreateArray(&_tlg_data[_tlg_idx], _tlg_temp##n, (cValues), sizeof(ctype), lttng_alignof(ctype)); \
+    _tlg_DataDescCreateArray(&_tlg_data[_tlg_idx], _tlg_temp##n, (cValues), sizeof(ctype), lttngh_ALIGNOF(ctype)); \
     _tlg_idx += 2;
-#define _tlg_DataDescCreate_tlg_IntFixedArray(n, ctype, pValues, cValues, intFieldType, isSigned, ndt) \
+#define _tlg_DataDescCreate_tlg_FixedArray(n, ctype, pValues, cValues, elementUstType, ndt) \
     ctype const *const _tlg_temp##n = (pValues);                                                       \
-    _tlg_data[_tlg_idx++] = lttngh_DataDescCreateCounted(_tlg_temp##n, (cValues) * sizeof(ctype), lttng_alignof(ctype), (cValues));
-#define _tlg_DataDescCreate_tlg_Float(n, ctype, value, ndt) \
-    ctype const _tlg_temp##n = (value);                     \
-    _tlg_data[_tlg_idx++] = lttngh_DataDescCreate(&_tlg_temp##n, sizeof(ctype), lttng_alignof(ctype), lttngh_DataType_Float);
-#define _tlg_DataDescCreate_tlg_FloatArray(n, ctype, pValues, cValues, ndt)                                       \
-    ctype const *const _tlg_temp##n = (pValues);                                                                  \
-    _tlg_DataDescCreateArray(&_tlg_data[_tlg_idx], _tlg_temp##n, (cValues), sizeof(ctype), lttng_alignof(ctype)); \
-    _tlg_idx += 2;
-#define _tlg_DataDescCreate_tlg_FloatFixedArray(n, ctype, pValues, cValues, ndt) \
-    ctype const *const _tlg_temp##n = (pValues);                                 \
-    _tlg_data[_tlg_idx++] = lttngh_DataDescCreateCounted(_tlg_temp##n, (cValues) * sizeof(ctype), lttng_alignof(ctype), (cValues));
+    _tlg_data[_tlg_idx++] = lttngh_DataDescCreateCounted(_tlg_temp##n, (cValues) * sizeof(ctype), lttngh_ALIGNOF(ctype), (cValues));
 #define _tlg_DataDescCreate_tlg_Char8(n, ctype, value, ndt) \
     ctype const _tlg_temp##n = (value);                     \
-    _tlg_data[_tlg_idx++] = lttngh_DataDescCreateCounted(&_tlg_temp##n, sizeof(ctype), lttng_alignof(ctype), 1);
+    _tlg_data[_tlg_idx++] = lttngh_DataDescCreateCounted(&_tlg_temp##n, sizeof(ctype), lttngh_ALIGNOF(ctype), 1);
 #define _tlg_DataDescCreate_tlg_CharW(n, ctype, value, ndt) \
-    ctype const _tlg_temp##n = (value);                          \
-    _tlg_data[_tlg_idx++] = lttngh_DataDescCreateSequenceWchar(&_tlg_temp##n, 1);
+    ctype const _tlg_temp##n[2] = { (value), 0 };           \
+    _tlg_data[_tlg_idx++] = lttngh_DataDescCreateStringWchar(_tlg_temp##n);
 #define _tlg_DataDescCreate_tlg_CharNN(n, ctype, value, NN, ndt) \
-    ctype const _tlg_temp##n = (value);                          \
-    _tlg_data[_tlg_idx++] = lttngh_DataDescCreateSequenceUtf##NN((char##NN##_t const *)&_tlg_temp##n, 1);
+    ctype const _tlg_temp##n[2] = { (value), 0 };           \
+    _tlg_data[_tlg_idx++] = lttngh_DataDescCreateStringUtf##NN((char##NN##_t const *)_tlg_temp##n);
 #define _tlg_DataDescCreate_tlg_String8(n, ctype, pszValue, ndt) \
     ctype const *const _tlg_temp##n = (pszValue);                \
     _tlg_data[_tlg_idx++] = lttngh_DataDescCreateString8(_tlg_temp##n ? _tlg_temp##n : "");
@@ -2632,7 +2589,7 @@ ctype const*)).
     _tlg_data[_tlg_idx++] = lttngh_DataDescCreateStringUtf##NN(_tlg_temp##n ? (char##NN##_t const *)_tlg_temp##n : (char##NN##_t const *)U"");
 #define _tlg_DataDescCreate_tlg_CountedString8(n, ctype, pchValue, cchValue, ndt)                                  \
     ctype const *const _tlg_temp##n = (pchValue);                                                                  \
-    _tlg_DataDescCreateArray(&_tlg_data[_tlg_idx], _tlg_temp##n, (cchValue), sizeof(ctype), lttng_alignof(ctype)); \
+    _tlg_DataDescCreateArray(&_tlg_data[_tlg_idx], _tlg_temp##n, (cchValue), sizeof(ctype), lttngh_ALIGNOF(ctype)); \
     _tlg_idx += 2;
 #define _tlg_DataDescCreate_tlg_CountedStringW(n, ctype, pchValue, cchValue, ndt) \
     ctype const *const _tlg_temp##n = (pchValue);                                      \
@@ -2642,50 +2599,64 @@ ctype const*)).
     _tlg_data[_tlg_idx++] = lttngh_DataDescCreateSequenceUtf##NN((char##NN##_t const *)_tlg_temp##n, (cchValue));
 #define _tlg_DataDescCreate_tlg_Binary(n, ctype, pValue, cbValue, ndt)                                                \
     ctype const *const _tlg_temp##n = (pValue);                                                                       \
-    _tlg_DataDescCreateArray(&_tlg_data[_tlg_idx], _tlg_temp##n, (cbValue), sizeof(uint8_t), lttng_alignof(uint8_t)); \
+    _tlg_DataDescCreateArray(&_tlg_data[_tlg_idx], _tlg_temp##n, (cbValue), sizeof(uint8_t), lttngh_ALIGNOF(uint8_t)); \
     _tlg_idx += 2;
 #define _tlg_DataDescCreate_tlg_Sid(n, ctype, pValue, ndt)                                                                             \
     ctype const *const _tlg_temp##n = (pValue);                                                                                        \
-    _tlg_DataDescCreateArray(&_tlg_data[_tlg_idx], _tlg_temp##n, _tlg_SidSize(_tlg_temp##n), sizeof(uint8_t), lttng_alignof(uint8_t)); \
+    _tlg_DataDescCreateArray(&_tlg_data[_tlg_idx], _tlg_temp##n, _tlg_SidSize(_tlg_temp##n), sizeof(uint8_t), lttngh_ALIGNOF(uint8_t)); \
     _tlg_idx += 2;
-#define _tlg_DataDescCreate_tlg_GuidPtr(n, ctype, pValue, name)                                                                       \
+#define _tlg_DataDescCreate_tlg_ActivityId(n, ctype, pValue, name)                                                                       \
     ctype const *const _tlg_temp##n = (pValue);                                                                                       \
-    _tlg_DataDescCreateTinyArray(&_tlg_data[_tlg_idx], _tlg_temp##n, _tlg_temp##n ? 16 : 0, sizeof(uint8_t), lttng_alignof(uint8_t)); \
+    _tlg_DataDescCreateTinyArray(&_tlg_data[_tlg_idx], _tlg_temp##n, _tlg_temp##n ? 16 : 0, sizeof(uint8_t), lttngh_ALIGNOF(uint8_t)); \
     _tlg_idx += 2;
 #define _tlg_DataDescCreate_tlg_Buffer(n, ctype, pValue, ndt)                                                                            \
     ctype const *const _tlg_temp##n = (pValue);                                                                                          \
-    _tlg_DataDescCreateArray(&_tlg_data[_tlg_idx], _tlg_temp##n->Buffer, _tlg_temp##n->Length, sizeof(uint8_t), lttng_alignof(uint8_t)); \
+    _tlg_DataDescCreateArray(&_tlg_data[_tlg_idx], _tlg_temp##n->Buffer, _tlg_temp##n->Length, sizeof(uint8_t), lttngh_ALIGNOF(uint8_t)); \
     _tlg_idx += 2;
+
 #endif // _cplusplus
 
+#if lttngh_UST_VER >= 213
+#define _tlg_InitTracepoint(_tlg_fullName) lttngh_INIT_TRACEPOINT(NULL, _tlg_fullName)
+#define _tlg_EventFieldArray(eventFieldCount, ...) \
+    _tlg_FOREACH(_tlg_EventField, __VA_ARGS__) \
+    static lttngh_ust_event_field const* const _tlg_eventFieldArray[eventFieldCount] = { \
+        _tlg_FOREACH(_tlg_EventFieldRef, __VA_ARGS__) };
+#else // lttngh_UST_VER
+#define _tlg_InitTracepoint(nameBuffer) lttngh_INIT_TRACEPOINT(nameBuffer)
+#define _tlg_EventFieldArray(eventFieldCount, ...) \
+    static lttngh_ust_event_field const _tlg_eventFieldArray[eventFieldCount] = { \
+        _tlg_FOREACH(_tlg_EventField, __VA_ARGS__) };
+#endif // lttngh_UST_VER
+
 #define _tlg_Write_imp(eventProbeFunc, providerSymbol, eventName, ...) ({ \
-    static char _tlg_fullName[LTTNG_UST_SYM_NAME_LEN]; /* Filled-in during TraceLoggingRegister. */ \
-    static struct lttng_event_field const _tlg_eventFields[0 _tlg_FOREACH(_tlg_FieldCount, __VA_ARGS__)] = { \
-        _tlg_FOREACH(_tlg_FieldInfo, __VA_ARGS__) };\
+    static char _tlg_fullName[lttngh_UST_SYM_NAME_LEN]; /* Filled-in during TraceLoggingRegister. */ \
+    enum { _tlg_eventFieldCount = 0 _tlg_FOREACH(_tlg_FieldCount, __VA_ARGS__) }; \
+    _tlg_EventFieldArray(_tlg_eventFieldCount, __VA_ARGS__) \
     static struct lttng_ust_tracepoint _tlg_tracepoint \
-        __attribute__((section("__tracepoints"))) = { \
-        _tlg_fullName, 0, NULL, NULL, "", {} }; \
+        __attribute__((section("__tracepoints"))) =  _tlg_InitTracepoint(_tlg_fullName); \
     static struct lttng_ust_tracepoint* _tlg_tracepointPtr \
-        __attribute__((section("__tracepoints_ptrs_" #providerSymbol), used)) = \
+        __attribute__((section("__tracepoints_ptrs_" _tlg_STRINGIZE(providerSymbol)), used)) = \
         &_tlg_tracepoint; \
-    static struct _tlg_Event_t const _tlg_event = { { \
-        _tlg_fullName, (void(*)(void))&lttngh_EventProbe, NULL, \
-        _tlg_eventFields, sizeof(_tlg_eventFields) / sizeof(struct lttng_event_field), \
-        (const int**)&_tlg_event.LevelPtr, "", {} }, \
+    static struct _tlg_Event_t const _tlg_event = { \
+        lttngh_INIT_EVENT_DESC(&_tlg_PASTE(_tlgProv_, providerSymbol).ProbeDesc, \
+            _tlg_fullName, (void(*)(void))&lttngh_EventProbe, \
+            _tlg_eventFieldArray, _tlg_eventFieldCount, \
+            (const int**)&_tlg_event.LevelPtr), \
         (0 _tlg_FOREACH(_tlg_KeywordVal, __VA_ARGS__)), \
         &_tlg_tracepoint, \
         ("" eventName), \
         &_tlg_event.Level, \
         (lttngh_Level_DEBUG _tlg_FOREACH(_tlg_LevelVal, __VA_ARGS__)) }; \
-    static struct lttng_event_desc const* _tlg_eventDescPtr \
-        __attribute__((section("__eventdesc_ptrs_" #providerSymbol), used)) = \
+    static lttngh_ust_event_desc const* _tlg_eventDescPtr \
+        __attribute__((section("__eventdesc_ptrs_" _tlg_STRINGIZE(providerSymbol)), used)) = \
         &_tlg_event.Desc; \
     int _tlg_err = 0; \
-    static_assert(sizeof("" eventName) <= LTTNG_UST_SYM_NAME_LEN - 6, \
+    static_assert(sizeof("" eventName) <= lttngh_UST_SYM_NAME_LEN - 6, \
         "TraceLoggingWrite eventName must be no more than 250 characters"); \
-    (void)&_tlgProv_##providerSymbol; /* Trigger a compile error for misspelled providerSymbol. */ \
+    (void)&_tlg_PASTE(_tlgProv_, providerSymbol); /* Trigger a compile error for misspelled providerSymbol. */ \
     if (caa_unlikely(CMM_LOAD_SHARED(_tlg_tracepoint.state))) { \
-        static unsigned const _tlg_idxMax = 0 _tlg_FOREACH(_tlg_DataDescCount, __VA_ARGS__); \
+        enum { _tlg_idxMax = 0 _tlg_FOREACH(_tlg_DataDescCount, __VA_ARGS__) }; \
         unsigned _tlg_idx = 0; \
         struct lttngh_DataDesc _tlg_data[_tlg_idxMax]; \
         _tlgBeginCppEval /* For C++, ensure no semicolons until after EventProbe. */ \

--- a/src/LttngHelpers.c
+++ b/src/LttngHelpers.c
@@ -7,43 +7,128 @@
 
 #include <lttngh/LttngHelpers.h>
 #include <byteswap.h>
-#include <lttng/ringbuffer-config.h> // lttng_ust_lib_ring_buffer_ctx
 #include <urcu/compiler.h>           // caa_unlikely
 #include <urcu/system.h>             // CMM_LOAD_SHARED
 
-#define lttngh_RCU_DEREFERENCE(p) URCU_FORCE_CAST( \
-    __typeof__(p),                                 \
-    tp_rcu_dereference_sym_bp(URCU_FORCE_CAST(void *, p)))
+#if lttngh_UST_VER >= 213
 
-extern int tracepoint_register_lib(struct lttng_ust_tracepoint *const *, int);
-extern int tracepoint_unregister_lib(struct lttng_ust_tracepoint *const *);
+#include <lttng/ust-ringbuffer-context.h> // lttng_ust_lib_ring_buffer_ctx
+#include <lttng/urcu/urcu-ust.h>      // lttng_ust_urcu_read_lock, etc.
+
+typedef struct lttng_ust_event_common lttngh_ust_event_common;
+
+typedef struct lttng_ust_enum_entry lttngh_ust_enum_entry;
+static const lttngh_ust_enum_entry BoolEnumEntry0 = lttngh_INIT_ENUM_ENTRY_UNSIGNED("false", 0, 0);
+static const lttngh_ust_enum_entry BoolEnumEntry1 = lttngh_INIT_ENUM_ENTRY_UNSIGNED("true", 1, 1);
+static const lttngh_ust_enum_entry* BoolEnumEntries[] = {
+    &BoolEnumEntry0,
+    &BoolEnumEntry1 };
+const lttngh_ust_enum_desc lttngh_BoolEnumDesc = lttngh_INIT_ENUM_DESC("bool", BoolEnumEntries, 2);
+
+const struct lttng_ust_type_integer  lttngh_TypeInt8     = lttngh_INIT_TYPE_INTEGER( int8_t, 10, 0);
+const struct lttng_ust_type_integer  lttngh_TypeUInt8    = lttngh_INIT_TYPE_INTEGER(uint8_t, 10, 0);
+const struct lttng_ust_type_integer  lttngh_TypeHexInt8  = lttngh_INIT_TYPE_INTEGER(uint8_t, 16, 0);
+
+const struct lttng_ust_type_integer  lttngh_TypeInt16    = lttngh_INIT_TYPE_INTEGER( int16_t, 10, 0);
+const struct lttng_ust_type_integer  lttngh_TypeUInt16   = lttngh_INIT_TYPE_INTEGER(uint16_t, 10, 0);
+const struct lttng_ust_type_integer  lttngh_TypeHexInt16 = lttngh_INIT_TYPE_INTEGER(uint16_t, 16, 0);
+const struct lttng_ust_type_integer  lttngh_TypeUInt16BE = lttngh_INIT_TYPE_INTEGER(uint16_t, 10, __BYTE_ORDER == __LITTLE_ENDIAN); // IP PORT
+
+const struct lttng_ust_type_integer  lttngh_TypeInt32    = lttngh_INIT_TYPE_INTEGER( int32_t, 10, 0);
+const struct lttng_ust_type_integer  lttngh_TypeUInt32   = lttngh_INIT_TYPE_INTEGER(uint32_t, 10, 0);
+const struct lttng_ust_type_integer  lttngh_TypeHexInt32 = lttngh_INIT_TYPE_INTEGER(uint32_t, 16, 0);
+
+const struct lttng_ust_type_integer  lttngh_TypeLong     = lttngh_INIT_TYPE_INTEGER(  signed long, 10, 0);
+const struct lttng_ust_type_integer  lttngh_TypeULong    = lttngh_INIT_TYPE_INTEGER(unsigned long, 10, 0);
+const struct lttng_ust_type_integer  lttngh_TypeHexLong  = lttngh_INIT_TYPE_INTEGER(unsigned long, 16, 0);
+
+const struct lttng_ust_type_integer  lttngh_TypeIntPtr   = lttngh_INIT_TYPE_INTEGER( intptr_t, 10, 0);
+const struct lttng_ust_type_integer  lttngh_TypeUIntPtr  = lttngh_INIT_TYPE_INTEGER(uintptr_t, 10, 0);
+const struct lttng_ust_type_integer  lttngh_TypeHexIntPtr= lttngh_INIT_TYPE_INTEGER(uintptr_t, 16, 0);
+
+const struct lttng_ust_type_integer  lttngh_TypeInt64    = lttngh_INIT_TYPE_INTEGER( int64_t, 10, 0);
+const struct lttng_ust_type_integer  lttngh_TypeUInt64   = lttngh_INIT_TYPE_INTEGER(uint64_t, 10, 0);
+const struct lttng_ust_type_integer  lttngh_TypeHexInt64 = lttngh_INIT_TYPE_INTEGER(uint64_t, 16, 0);
+
+const struct lttng_ust_type_float    lttngh_TypeFloat32  = lttngh_INIT_TYPE_FLOAT(float);
+const struct lttng_ust_type_float    lttngh_TypeFloat64  = lttngh_INIT_TYPE_FLOAT(double);
+
+const struct lttng_ust_type_enum     lttngh_TypeBool8    = lttngh_INIT_TYPE_ENUM(lttngh_TypeUInt8, lttngh_BoolEnumDesc); // bool8 = enum : uint8_t
+const struct lttng_ust_type_enum     lttngh_TypeBool32   = lttngh_INIT_TYPE_ENUM(lttngh_TypeInt32, lttngh_BoolEnumDesc); // bool32 = enum : int32_t
+
+const struct lttng_ust_type_sequence lttngh_TypeInt8Sequence     = lttngh_INIT_TYPE_SEQUENCE(lttngh_TypeInt8, NULL, lttngh_ALIGNOF(int8_t));
+const struct lttng_ust_type_sequence lttngh_TypeUInt8Sequence    = lttngh_INIT_TYPE_SEQUENCE(lttngh_TypeUInt8, NULL, lttngh_ALIGNOF(int8_t));
+const struct lttng_ust_type_sequence lttngh_TypeHexInt8Sequence  = lttngh_INIT_TYPE_SEQUENCE(lttngh_TypeHexInt8, NULL, lttngh_ALIGNOF(int8_t));
+
+const struct lttng_ust_type_sequence lttngh_TypeInt16Sequence    = lttngh_INIT_TYPE_SEQUENCE(lttngh_TypeInt16, NULL, lttngh_ALIGNOF(int16_t));
+const struct lttng_ust_type_sequence lttngh_TypeUInt16Sequence   = lttngh_INIT_TYPE_SEQUENCE(lttngh_TypeUInt16, NULL, lttngh_ALIGNOF(int16_t));
+const struct lttng_ust_type_sequence lttngh_TypeHexInt16Sequence = lttngh_INIT_TYPE_SEQUENCE(lttngh_TypeHexInt16, NULL, lttngh_ALIGNOF(int16_t));
+
+const struct lttng_ust_type_sequence lttngh_TypeInt32Sequence    = lttngh_INIT_TYPE_SEQUENCE(lttngh_TypeInt32, NULL, lttngh_ALIGNOF(int32_t));
+const struct lttng_ust_type_sequence lttngh_TypeUInt32Sequence   = lttngh_INIT_TYPE_SEQUENCE(lttngh_TypeUInt32, NULL, lttngh_ALIGNOF(int32_t));
+const struct lttng_ust_type_sequence lttngh_TypeHexInt32Sequence = lttngh_INIT_TYPE_SEQUENCE(lttngh_TypeHexInt32, NULL, lttngh_ALIGNOF(int32_t));
+
+const struct lttng_ust_type_sequence lttngh_TypeLongSequence     = lttngh_INIT_TYPE_SEQUENCE(lttngh_TypeLong, NULL, lttngh_ALIGNOF(long));
+const struct lttng_ust_type_sequence lttngh_TypeULongSequence    = lttngh_INIT_TYPE_SEQUENCE(lttngh_TypeULong, NULL, lttngh_ALIGNOF(long));
+const struct lttng_ust_type_sequence lttngh_TypeHexLongSequence  = lttngh_INIT_TYPE_SEQUENCE(lttngh_TypeHexLong, NULL, lttngh_ALIGNOF(long));
+
+const struct lttng_ust_type_sequence lttngh_TypeIntPtrSequence   = lttngh_INIT_TYPE_SEQUENCE(lttngh_TypeIntPtr, NULL, lttngh_ALIGNOF(intptr_t));
+const struct lttng_ust_type_sequence lttngh_TypeUIntPtrSequence  = lttngh_INIT_TYPE_SEQUENCE(lttngh_TypeUIntPtr, NULL, lttngh_ALIGNOF(intptr_t));
+const struct lttng_ust_type_sequence lttngh_TypeHexIntPtrSequence= lttngh_INIT_TYPE_SEQUENCE(lttngh_TypeHexIntPtr, NULL, lttngh_ALIGNOF(intptr_t));
+
+const struct lttng_ust_type_sequence lttngh_TypeInt64Sequence    = lttngh_INIT_TYPE_SEQUENCE(lttngh_TypeInt64, NULL, lttngh_ALIGNOF(int64_t));
+const struct lttng_ust_type_sequence lttngh_TypeUInt64Sequence   = lttngh_INIT_TYPE_SEQUENCE(lttngh_TypeUInt64, NULL, lttngh_ALIGNOF(int64_t));
+const struct lttng_ust_type_sequence lttngh_TypeHexInt64Sequence = lttngh_INIT_TYPE_SEQUENCE(lttngh_TypeHexInt64, NULL, lttngh_ALIGNOF(int64_t));
+
+//const struct lttng_ust_type_sequence lttngh_TypeFloat32Sequence = lttngh_INIT_TYPE_SEQUENCE(lttngh_TypeFloat32, NULL, lttngh_ALIGNOF(float));
+//const struct lttng_ust_type_sequence lttngh_TypeFloat64Sequence = lttngh_INIT_TYPE_SEQUENCE(lttngh_TypeFloat64, NULL, lttngh_ALIGNOF(double));
+
+const struct lttng_ust_type_sequence lttngh_TypeBool8Sequence  = lttngh_INIT_TYPE_SEQUENCE(lttngh_TypeUInt8, NULL, lttngh_ALIGNOF(int8_t));
+const struct lttng_ust_type_sequence lttngh_TypeBool32Sequence = lttngh_INIT_TYPE_SEQUENCE(lttngh_TypeInt32, NULL, lttngh_ALIGNOF(int32_t));
+
+const struct lttng_ust_type_string   lttngh_TypeUtf8String   = lttngh_INIT_TYPE_CHAR8_STRING(UTF8);
+const struct lttng_ust_type_sequence lttngh_TypeUtf8Sequence = lttngh_INIT_TYPE_CHAR8_SEQUENCE(UTF8, NULL);
+
+const struct lttng_ust_type_array    lttngh_TypeUtf8Char   = lttngh_INIT_TYPE_CHAR8_ARRAY(UTF8, 1);
+const struct lttng_ust_type_array    lttngh_TypeGuid       = lttngh_INIT_TYPE_ARRAY(lttngh_TypeHexInt8, 16, lttngh_ALIGNOF(int8_t));
+const struct lttng_ust_type_array    lttngh_TypeSystemTime = lttngh_INIT_TYPE_ARRAY(lttngh_TypeUInt16, 8, lttngh_ALIGNOF(int16_t));
+const struct lttng_ust_type_array    lttngh_TypeFileTime   = lttngh_INIT_TYPE_ARRAY(lttngh_TypeUInt64, 1, lttngh_ALIGNOF(int64_t));
+const struct lttng_ust_type_sequence lttngh_TypeActivityId = lttngh_INIT_TYPE_SEQUENCE(lttngh_TypeHexInt8, NULL, lttngh_ALIGNOF(int8_t));
+
+extern int lttng_ust_tracepoint_module_register(struct lttng_ust_tracepoint* const* tracepoints_start, int tracepoints_count);
+extern int lttng_ust_tracepoint_module_unregister(struct lttng_ust_tracepoint* const* tracepoints_start);
+#define lttngh_ust_tracepoint_module_register   lttng_ust_tracepoint_module_register
+#define lttngh_ust_tracepoint_module_unregister lttng_ust_tracepoint_module_unregister
+
+#else // lttngh_UST_VER
+
+#include <lttng/ringbuffer-config.h> // lttng_ust_lib_ring_buffer_ctx
+
+typedef struct lttng_event lttngh_ust_event_common;
+
+#if lttngh_UST_VER >= 208
+typedef struct lttng_enum_entry lttngh_ust_enum_entry;
+static const lttngh_ust_enum_entry BoolEnumEntries[] = {
+    lttngh_INIT_ENUM_ENTRY_UNSIGNED("false", 0, 0),
+    lttngh_INIT_ENUM_ENTRY_UNSIGNED("true", 1, 1) };
+const lttngh_ust_enum_desc lttngh_BoolEnumDesc = lttngh_INIT_ENUM_DESC("bool", BoolEnumEntries, 2);
+#endif // lttngh_UST_VER
+
 extern void tp_rcu_read_lock_bp(void);
 extern void tp_rcu_read_unlock_bp(void);
 extern void *tp_rcu_dereference_sym_bp(void *);
+#define lttng_ust_urcu_read_lock() tp_rcu_read_lock_bp()
+#define lttng_ust_urcu_read_unlock() tp_rcu_read_unlock_bp()
+#define lttng_ust_rcu_dereference(p) URCU_FORCE_CAST( \
+    __typeof__(p),                                 \
+    tp_rcu_dereference_sym_bp(URCU_FORCE_CAST(void *, p)))
 
-#ifdef USE_LTTNG_2_7
-#define EnumEntryUnsigned(n, name) \
-    {                              \
-        (n), (n), name, {}         \
-    }
-#else
-#define EnumEntryUnsigned(n, name)   \
-    {                                \
-        {(n), 0}, {(n), 0}, name, {} \
-    }
-#endif
+extern int tracepoint_register_lib(struct lttng_ust_tracepoint* const* tracepoints_start, int tracepoints_count);
+extern int tracepoint_unregister_lib(struct lttng_ust_tracepoint* const* tracepoints_start);
+#define lttngh_ust_tracepoint_module_register   tracepoint_register_lib
+#define lttngh_ust_tracepoint_module_unregister tracepoint_unregister_lib
 
-static struct lttng_enum_entry const BoolEnumEntries[] = {
-    EnumEntryUnsigned(0, "false"),
-    EnumEntryUnsigned(1, "true")};
-
-#ifdef USE_LTTNG_2_7
-struct lttng_enum const lttngh_BoolEnumDesc = {
-    "bool", {atype_enum, {}}, BoolEnumEntries, 2, {}};
-#else
-struct lttng_enum_desc const lttngh_BoolEnumDesc = {
-    "bool", BoolEnumEntries, 2, {}};
-#endif
+#endif // lttngh_UST_VER
 
 static unsigned Utf16ToUtf8Size(
     char16_t const *pch16,
@@ -304,17 +389,18 @@ static unsigned Utf32ToUtf8(
 }
 
 static void ProviderError(
-    struct lttng_probe_desc *pProbeDesc,
+    lttngh_ust_probe_desc *pProbeDesc,
     int err,
     const char *msg)
     __attribute__((noreturn)) lttng_ust_notrace;
 static void ProviderError(
-    struct lttng_probe_desc *pProbeDesc,
+    lttngh_ust_probe_desc *pProbeDesc,
     int err,
     const char *msg)
 {
     fprintf(stderr, "LTTng-UST: provider \"%s\" error %d: %s\n",
-            pProbeDesc->provider, err, msg);
+        lttngh_PROVIDER_NAME(*pProbeDesc),
+        err, msg);
     abort();
 }
 
@@ -351,7 +437,8 @@ static void *FixArray(
         {
             if (*ppGood == *(ppGood + 1))
             {
-                for (void const **ppNext = ppGood + 2; ppNext != ppEnd; ppNext += 1)
+                void const** ppNext;
+                for (ppNext = ppGood + 2; ppNext != ppEnd; ppNext += 1)
                 {
                     if (*ppGood != *ppNext)
                     {
@@ -374,17 +461,18 @@ static void *FixArray(
 
 // ust-tracepoint-event.h(991) __lttng_events_init
 int lttngh_RegisterProvider(
-    int volatile *pIsRegistered,
-    struct lttng_probe_desc *pProbeDesc,
+    lttngh_registration* pRegistration,
+    lttngh_ust_probe_desc *pProbeDesc,
     struct lttng_ust_tracepoint **pTracepointStart,
     struct lttng_ust_tracepoint **pTracepointStop,
-    struct lttng_event_desc const **pEventDescStart,
-    struct lttng_event_desc const **pEventDescStop)
+    lttngh_ust_event_desc const **pEventDescStart,
+    lttngh_ust_event_desc const **pEventDescStop)
 {
     int err;
+    int volatile* const pIsRegistered = lttngh_REGISTRATION_STATE(*pRegistration);
 
     // Note: not intended to support multithreaded or ref-counted registration.
-    // pIsRegistered is used to make it safe to call Unregister on an
+    // pRegistration is used to make it safe to call Unregister on an
     // unregistered lib and to help detect misuse, not to make this thread-safe.
     if (__atomic_exchange_n(pIsRegistered, 1, __ATOMIC_RELAXED) != 0)
     {
@@ -394,12 +482,18 @@ int lttngh_RegisterProvider(
     }
     else
     {
-        struct lttng_event_desc const **const pEventDescLast =
-            (struct lttng_event_desc const **)FixArray(
+        lttngh_ust_event_desc const **const pEventDescLast =
+            (lttngh_ust_event_desc const **)FixArray(
                 (void const **)pEventDescStart, (void const **)pEventDescStop);
         pProbeDesc->event_desc = pEventDescStart;
         pProbeDesc->nr_events = (unsigned)(pEventDescLast - pEventDescStart);
+#if lttngh_UST_VER >= 213
+        pRegistration->registered_probe = lttng_ust_probe_register(pProbeDesc);
+        pRegistration->tracepoint_start = pTracepointStart;
+        err = pRegistration->registered_probe ? 0 : ENOMEM;
+#else // lttngh_UST_VER
         err = lttng_probe_register(pProbeDesc);
+#endif // lttngh_UST_VER
         if (err != 0)
         {
             ProviderError(pProbeDesc, err,
@@ -414,10 +508,15 @@ int lttngh_RegisterProvider(
                     (void const **)pTracepointStart, (void const **)pTracepointStop);
 
             // May fail for out-of-memory. Continue anyway.
-            err = tracepoint_register_lib(pTracepointStart, (int)(pTracepointLast - pTracepointStart));
+            err = lttngh_ust_tracepoint_module_register(pTracepointStart, (int)(pTracepointLast - pTracepointStart));
             if (err != 0)
             {
+#if lttngh_UST_VER >= 213
+                lttng_ust_probe_unregister(pRegistration->registered_probe);
+#else // lttngh_UST_VER
                 lttng_probe_unregister(pProbeDesc);
+#endif // lttngh_UST_VER
+
                 __atomic_exchange_n(pIsRegistered, 0, __ATOMIC_RELAXED);
             }
         }
@@ -428,38 +527,56 @@ int lttngh_RegisterProvider(
 
 // ust-tracepoint-event.h(1018) __lttng_events_exit
 int lttngh_UnregisterProvider(
-    int volatile *pIsRegistered,
-    struct lttng_probe_desc *pProbeDesc,
-    struct lttng_ust_tracepoint *const *pTracepointStart)
+    lttngh_registration* pRegistration
+#if lttngh_UST_VER < 213
+    ,
+    lttngh_ust_probe_desc* pProbeDesc,
+    struct lttng_ust_tracepoint* const* pTracepointStart
+#endif // lttngh_UST_VER
+    )
 {
     int err = 0;
+    int volatile* const pIsRegistered = lttngh_REGISTRATION_STATE(*pRegistration);
 
     // Calling Unregister on an unregistered lib is a safe no-op as long as it
     // doesn't race with a Register (which is a bug in the caller).
     if (__atomic_exchange_n(pIsRegistered, 0, __ATOMIC_RELAXED) != 0)
     {
-        err = tracepoint_unregister_lib(pTracepointStart);
+
+#if lttngh_UST_VER >= 213
+        err = lttngh_ust_tracepoint_module_unregister(pRegistration->tracepoint_start);
+        lttng_ust_probe_unregister(pRegistration->registered_probe);
+#else // lttngh_UST_VER
+        err = lttngh_ust_tracepoint_module_unregister(pTracepointStart);
         lttng_probe_unregister(pProbeDesc);
+#endif // lttngh_UST_VER
     }
 
     return err;
 }
 
 static int EventProbeFilter(
-    struct lttng_event const *pEvent,
+    lttngh_ust_event_common const *pEvent,
+#if lttngh_UST_VER >= 213
+    void* pCallerIp,
+#endif
     struct lttngh_DataDesc const *pDataDesc,
     unsigned cDataDesc)
     lttng_ust_notrace;
 static int EventProbeFilter(
-    struct lttng_event const *pEvent,
+    lttngh_ust_event_common const *pEvent,
+#if lttngh_UST_VER >= 213
+    void* pCallerIp,
+#endif
     struct lttngh_DataDesc const *pDataDesc,
     unsigned cDataDesc)
 {
-    int filterRecord = pEvent->has_enablers_without_bytecode;
+    int enableRecorder;
     unsigned cbBuffer;
+    unsigned i;
 
     cbBuffer = 0;
-    for (unsigned i = 0; i != cDataDesc; i += 1)
+    for (i = 0; i != cDataDesc; i += 1)
     {
         switch (pDataDesc[i].Type)
         {
@@ -498,7 +615,7 @@ static int EventProbeFilter(
         char stackData[cbBuffer] __attribute__((aligned(sizeof(size_t)))); // VLA
         char *pStackData = stackData;
 
-        for (unsigned i = 0; i != cDataDesc; i += 1)
+        for (i = 0; i != cDataDesc; i += 1)
         {
             switch (pDataDesc[i].Type)
             {
@@ -796,20 +913,320 @@ static int EventProbeFilter(
             }
         }
 
-        for (struct lttng_bytecode_runtime *pRuntime = cds_list_entry(
-                 lttngh_RCU_DEREFERENCE(pEvent->bytecode_runtime_head.next), __typeof__(*pRuntime), node);
+#if lttngh_UST_VER >= 213
+
+        struct lttng_ust_probe_ctx probeCtx = {
+            .struct_size = sizeof(probeCtx),
+            .ip = pCallerIp };
+        enableRecorder =
+            !pEvent->eval_filter ||
+            pEvent->run_filter(pEvent, stackData, &probeCtx, NULL) == LTTNG_UST_EVENT_FILTER_ACCEPT;
+        if (enableRecorder &&
+            pEvent->type == LTTNG_UST_EVENT_TYPE_NOTIFIER)
+        {
+            struct lttng_ust_event_notifier* pEventNotifier = (struct lttng_ust_event_notifier*)pEvent->child;
+            struct lttng_ust_notification_ctx context = {
+                .struct_size = sizeof(struct lttng_ust_notification_ctx),
+                .eval_capture = CMM_ACCESS_ONCE(pEventNotifier->eval_capture) };
+            pEventNotifier->notification_send(pEventNotifier, stackData, &probeCtx, &context);
+        }
+
+#else // lttngh_UST_VER
+
+        enableRecorder = pEvent->has_enablers_without_bytecode;
+        struct lttng_bytecode_runtime* pRuntime;
+        for (pRuntime = cds_list_entry(
+                 lttng_ust_rcu_dereference(pEvent->bytecode_runtime_head.next), __typeof__(*pRuntime), node);
              &pRuntime->node != &pEvent->bytecode_runtime_head;
              pRuntime = cds_list_entry(
-                 lttngh_RCU_DEREFERENCE(pRuntime->node.next), __typeof__(*pRuntime), node))
+                 lttng_ust_rcu_dereference(pRuntime->node.next), __typeof__(*pRuntime), node))
         {
             if (caa_unlikely(pRuntime->filter(pRuntime, stackData) & LTTNG_FILTER_RECORD_FLAG))
             {
-                filterRecord = 1;
+                enableRecorder = 1;
             }
+        }
+
+#endif // lttngh_UST_VER
+    }
+
+    return enableRecorder;
+}
+
+struct lttngh_EventProbeContext
+{
+    unsigned maxAlign;
+    unsigned cbData;
+    unsigned char* pbTranscodeScratch;
+    unsigned cbTranscodeScratch;
+};
+
+static int EventProbeComputeSizes(
+    struct lttngh_EventProbeContext* pContext,
+    struct lttngh_DataDesc* pDataDesc,
+    unsigned cDataDesc)
+    lttng_ust_notrace;
+static int EventProbeComputeSizes(
+    struct lttngh_EventProbeContext* pContext,
+    struct lttngh_DataDesc* pDataDesc,
+    unsigned cDataDesc)
+{
+    unsigned cbTranscodeWanted = 0;
+
+    pContext->maxAlign = 1;
+    assert(pContext->cbData == 0);
+
+    unsigned i;
+    for (i = 0; i != cDataDesc; i += 1)
+    {
+        switch (pDataDesc[i].Type)
+        {
+        case lttngh_DataType_StringUtf16Transcoded:
+        case lttngh_DataType_StringUtf32Transcoded:
+        {
+            unsigned cbUtf8;
+
+            if (pDataDesc[i].Type == lttngh_DataType_StringUtf16Transcoded)
+            {
+                unsigned cch16 = pDataDesc[i].Size / sizeof(char16_t);
+                assert(cch16 != 0); // Error in caller - Size should have included NUL.
+                cch16 -= 1;         // Do not count NUL.
+
+                if (caa_unlikely(cch16 > 65535))
+                {
+                    if (cch16 == ~0u)
+                    {
+                        cch16 = 0; // Error in caller - Size was 0.
+                    }
+                    else
+                    {
+                        cch16 = 65535;
+                    }
+                }
+
+                cbUtf8 = Utf16ToUtf8Size(pDataDesc[i].Data, cch16);
+            }
+            else
+            {
+                unsigned cch32 = pDataDesc[i].Size / sizeof(char32_t);
+                assert(cch32 != 0); // Error in caller - Size should have included NUL.
+                cch32 -= 1;         // Do not count NUL.
+
+                if (caa_unlikely(cch32 > 65535))
+                {
+                    if (cch32 == ~0u)
+                    {
+                        cch32 = 0; // Error in caller - Size was 0.
+                    }
+                    else
+                    {
+                        cch32 = 65535;
+                    }
+                }
+
+                cbUtf8 = Utf32ToUtf8Size(pDataDesc[i].Data, cch32);
+            }
+
+            if (caa_unlikely(cbUtf8 > 65535))
+            {
+                cbUtf8 = 65535;
+            }
+
+            // Use DataDesc.Length as scratch space to store utf-8 content size.
+            pDataDesc[i].Length = (uint16_t)cbUtf8; // Does not count NUL.
+
+            cbUtf8 += 1; // Include room for 8-bit NUL.
+            if (caa_unlikely(cbTranscodeWanted < cbUtf8))
+            {
+                cbTranscodeWanted = cbUtf8;
+            }
+
+            pContext->cbData += cbUtf8;
+            if (caa_unlikely(pContext->cbData < cbUtf8))
+            {
+                return EOVERFLOW;
+            }
+            break;
+        }
+        case lttngh_DataType_SequenceUtf16Transcoded:
+        case lttngh_DataType_SequenceUtf32Transcoded:
+        {
+#if lttngh_UST_RING_BUFFER_NATURAL_ALIGN
+            if (__alignof__(uint16_t) > pContext->maxAlign)
+            {
+                pContext->maxAlign = __alignof__(uint16_t);
+            }
+
+            unsigned const alignAdjust =
+                lib_ring_buffer_align(pContext->cbData, __alignof__(uint16_t));
+            pContext->cbData += alignAdjust;
+            if (caa_unlikely(pContext->cbData < alignAdjust))
+            {
+                return EOVERFLOW;
+            }
+#endif // lttngh_UST_RING_BUFFER_NATURAL_ALIGN
+
+            unsigned cbUtf8;
+
+            if (pDataDesc[i].Type == lttngh_DataType_SequenceUtf16Transcoded)
+            {
+                unsigned cch16 = pDataDesc[i].Size / sizeof(char16_t);
+                if (caa_unlikely(cch16 > 65535))
+                {
+                    cch16 = 65535;
+                }
+
+                cbUtf8 = Utf16ToUtf8Size(pDataDesc[i].Data, cch16);
+            }
+            else
+            {
+                unsigned cch32 = pDataDesc[i].Size / sizeof(char32_t);
+                if (caa_unlikely(cch32 > 65535))
+                {
+                    cch32 = 65535;
+                }
+
+                cbUtf8 = Utf32ToUtf8Size(pDataDesc[i].Data, cch32);
+            }
+
+            if (caa_unlikely(cbUtf8 > 65535))
+            {
+                cbUtf8 = 65535;
+            }
+
+            // Use DataDesc.Length as scratch space to store utf-8 content size.
+            pDataDesc[i].Length = (uint16_t)cbUtf8;
+
+            cbUtf8 += 2; // Include room for 16-bit length.
+            if (caa_unlikely(cbTranscodeWanted < cbUtf8))
+            {
+                cbTranscodeWanted = cbUtf8;
+            }
+
+            pContext->cbData += cbUtf8;
+            if (caa_unlikely(pContext->cbData < cbUtf8))
+            {
+                return EOVERFLOW;
+            }
+            break;
+        }
+        default:
+        {
+#if lttngh_UST_RING_BUFFER_NATURAL_ALIGN
+            if (pDataDesc[i].Alignment > pContext->maxAlign)
+            {
+                pContext->maxAlign = pDataDesc[i].Alignment;
+            }
+
+            unsigned const alignAdjust =
+                lib_ring_buffer_align(pContext->cbData, pDataDesc[i].Alignment);
+            pContext->cbData += alignAdjust;
+            if (caa_unlikely(pContext->cbData < alignAdjust))
+            {
+                return EOVERFLOW;
+            }
+#endif // lttngh_UST_RING_BUFFER_NATURAL_ALIGN
+
+            pContext->cbData += pDataDesc[i].Size;
+            if (pContext->cbData < pDataDesc[i].Size)
+            {
+                return EOVERFLOW;
+            }
+            break;
+        }
         }
     }
 
-    return filterRecord;
+    // If our scratch buffer is too small, try to heap allocate.
+    if (caa_unlikely(pContext->cbTranscodeScratch < cbTranscodeWanted))
+    {
+        unsigned char* pbTranscodeWanted = (unsigned char*)malloc(cbTranscodeWanted);
+        if (caa_unlikely(pbTranscodeWanted == NULL))
+        {
+            return ENOMEM;
+        }
+
+        pContext->cbTranscodeScratch = cbTranscodeWanted;
+        pContext->pbTranscodeScratch = pbTranscodeWanted;
+    }
+
+    return 0;
+}
+
+static uint16_t EventProbeTranscodeString(
+    struct lttngh_EventProbeContext* pContext,
+    struct lttngh_DataDesc const* pDataDesc)
+    lttng_ust_notrace;
+static uint16_t EventProbeTranscodeString(
+    struct lttngh_EventProbeContext* pContext,
+    struct lttngh_DataDesc const* pDataDesc)
+{
+    assert(pDataDesc->Length <= pContext->cbTranscodeScratch - 1);
+
+    uint16_t cbUtf8Written;
+    if (pDataDesc->Type == lttngh_DataType_StringUtf16Transcoded)
+    {
+        cbUtf8Written = (uint16_t)Utf16ToUtf8(
+            pDataDesc->Data, pDataDesc->Size / sizeof(char16_t),
+            pContext->pbTranscodeScratch, pDataDesc->Length);
+    }
+    else
+    {
+        cbUtf8Written = (uint16_t)Utf32ToUtf8(
+            pDataDesc->Data, pDataDesc->Size / sizeof(char32_t),
+            pContext->pbTranscodeScratch, pDataDesc->Length);
+    }
+
+    pContext->pbTranscodeScratch[cbUtf8Written] = 0;
+    size_t iNul = strlen((char*)pContext->pbTranscodeScratch);
+    if (caa_unlikely(iNul != pDataDesc->Length))
+    {
+        // The data was changed on another thread or was truncated at a multi-byte char, so append #s.
+        assert(iNul <= cbUtf8Written);
+        assert(cbUtf8Written < pDataDesc->Length);
+        memset(pContext->pbTranscodeScratch + iNul,
+            '#', pDataDesc->Length - iNul);
+        pContext->pbTranscodeScratch[pDataDesc->Length] = 0;
+    }
+
+    return cbUtf8Written;
+}
+
+static uint16_t EventProbeTranscodeSequence(
+    struct lttngh_EventProbeContext* pContext,
+    struct lttngh_DataDesc const* pDataDesc)
+    lttng_ust_notrace;
+static uint16_t EventProbeTranscodeSequence(
+    struct lttngh_EventProbeContext* pContext,
+    struct lttngh_DataDesc const* pDataDesc)
+{
+    assert(pDataDesc->Length <= pContext->cbTranscodeScratch - sizeof(uint16_t));
+
+    uint16_t cbUtf8Written;
+    if (pDataDesc->Type == lttngh_DataType_SequenceUtf16Transcoded)
+    {
+        cbUtf8Written = (uint16_t)Utf16ToUtf8(
+            pDataDesc->Data, pDataDesc->Size / sizeof(char16_t),
+            pContext->pbTranscodeScratch + sizeof(uint16_t), pDataDesc->Length);
+    }
+    else
+    {
+        cbUtf8Written = (uint16_t)Utf32ToUtf8(
+            pDataDesc->Data, pDataDesc->Size / sizeof(char32_t),
+            pContext->pbTranscodeScratch + sizeof(uint16_t), pDataDesc->Length);
+    }
+
+    if (caa_unlikely(cbUtf8Written != pDataDesc->Length))
+    {
+        // The data was changed on another thread or was truncated at a multi-byte char, so append #s.
+        assert(cbUtf8Written < pDataDesc->Length);
+        memset(pContext->pbTranscodeScratch + sizeof(uint16_t) + cbUtf8Written,
+            '#', pDataDesc->Length - (unsigned)cbUtf8Written);
+        cbUtf8Written = pDataDesc->Length;
+    }
+
+    memcpy(pContext->pbTranscodeScratch, &cbUtf8Written, sizeof(uint16_t)); // Fill in length.
+    return cbUtf8Written;
 }
 
 int lttngh_EventProbe(
@@ -820,26 +1237,119 @@ int lttngh_EventProbe(
 {
     int err = 0;
     struct lttng_ust_tracepoint_probe *pTpProbe;
-
-    unsigned maxAlign = 0; // 0 means we haven't computed event size yet.
-    unsigned cbData = 0;
     unsigned char transcodeScratchOnStack[256] __attribute__((aligned(2)));
-    unsigned char *pbTranscodeScratch = transcodeScratchOnStack;
-    unsigned cbTranscodeScratch = sizeof(transcodeScratchOnStack);
-    unsigned cbTranscodeWanted = 0;
+
+    struct lttngh_EventProbeContext context = {
+        .maxAlign = 0, // 0 means we haven't computed event size yet.
+        .cbData = 0,
+        .pbTranscodeScratch = transcodeScratchOnStack,
+        .cbTranscodeScratch = sizeof(transcodeScratchOnStack) };
 
     if (pCallerIp == NULL)
     {
         pCallerIp = lttngh_IP_PARAM;
     }
 
-    tp_rcu_read_lock_bp();
-    pTpProbe = lttngh_RCU_DEREFERENCE(pTracepoint->probes);
+    lttng_ust_urcu_read_lock();
+    pTpProbe = lttng_ust_rcu_dereference(pTracepoint->probes);
     if (caa_likely(pTpProbe))
     {
         do
         {
-            struct lttng_event *const pEvent = (struct lttng_event *const)pTpProbe->data;
+            lttngh_ust_event_common* const pEvent = (lttngh_ust_event_common* const)pTpProbe->data;
+
+#if lttngh_UST_VER >= 213
+
+            if (caa_likely(pEvent->type == LTTNG_UST_EVENT_TYPE_RECORDER))
+            {
+                struct lttng_ust_event_recorder* pEventRecorder = (struct lttng_ust_event_recorder*)pEvent->child;
+                struct lttng_ust_channel_common* pChannelCommon = pEventRecorder->chan->parent;
+
+                if (
+#ifdef TP_SESSION_CHECK // Are we building statedump?
+                    session != pChannelCommon->session ||
+#endif // TP_SESSION_CHECK
+                    caa_unlikely(!CMM_ACCESS_ONCE(pChannelCommon->session->active)) ||
+                    caa_unlikely(!CMM_ACCESS_ONCE(pChannelCommon->enabled)))
+                {
+                    continue;
+                }
+
+                if (caa_unlikely(!CMM_ACCESS_ONCE(pEvent->enabled)))
+                {
+                    continue;
+                }
+
+                if (caa_unlikely(CMM_ACCESS_ONCE(pEvent->eval_filter)) &&
+                    !caa_unlikely(EventProbeFilter(pEvent, pCallerIp, pDataDesc, cDataDesc)))
+                {
+                    continue;
+                }
+
+                // Compute event size the first time through.
+                if (caa_likely(context.maxAlign == 0))
+                {
+                    err = EventProbeComputeSizes(&context, pDataDesc, cDataDesc);
+                    if (err != 0)
+                    {
+                        goto Done;
+                    }
+                }
+
+                struct lttng_ust_channel_buffer* pChannel = pEventRecorder->chan;
+
+                struct lttng_ust_ring_buffer_ctx bufferContext;
+                lttng_ust_ring_buffer_ctx_init(&bufferContext, pEventRecorder, context.cbData, context.maxAlign, pCallerIp);
+
+                int const reserveResult = pChannel->ops->event_reserve(&bufferContext);
+                if (caa_unlikely(reserveResult < 0))
+                {
+                    err = reserveResult;
+                }
+                else
+                {
+                    unsigned i;
+                    for (i = 0; i != cDataDesc; i += 1)
+                    {
+                        uint16_t cbUtf8Written;
+                        switch (pDataDesc[i].Type)
+                        {
+                        case lttngh_DataType_String8:
+                            pChannel->ops->event_strcpy(&bufferContext, pDataDesc[i].Data, pDataDesc[i].Size);
+                            break;
+
+                        case lttngh_DataType_StringUtf16Transcoded:
+                        case lttngh_DataType_StringUtf32Transcoded:
+                            cbUtf8Written = EventProbeTranscodeString(&context, &pDataDesc[i]);
+                            pChannel->ops->event_write(&bufferContext, context.pbTranscodeScratch, cbUtf8Written + 1u, pDataDesc[i].Alignment);
+                            break;
+
+                        case lttngh_DataType_SequenceUtf16Transcoded:
+                        case lttngh_DataType_SequenceUtf32Transcoded:
+                            cbUtf8Written = EventProbeTranscodeSequence(&context, &pDataDesc[i]);
+                            pChannel->ops->event_write(&bufferContext, context.pbTranscodeScratch, sizeof(uint16_t) + cbUtf8Written, pDataDesc[i].Alignment);
+                            break;
+
+                        default:
+                            pChannel->ops->event_write(&bufferContext, pDataDesc[i].Data, pDataDesc[i].Size, pDataDesc[i].Alignment);
+                            break;
+                        }
+                    }
+
+                    pChannel->ops->event_commit(&bufferContext);
+                }
+            }
+            else if (caa_likely(CMM_ACCESS_ONCE(pEvent->enabled)))
+            {
+                if (caa_likely(pEvent->type == LTTNG_UST_EVENT_TYPE_NOTIFIER) ||
+                    caa_unlikely(CMM_ACCESS_ONCE(pEvent->eval_filter)))
+                {
+                    (void)EventProbeFilter(pEvent, pCallerIp, pDataDesc, cDataDesc);
+                }
+            }
+
+#else // lttngh_UST_VER
+
             struct lttng_channel const *const pChannel = pEvent->chan;
 
             if (caa_likely(CMM_ACCESS_ONCE(pChannel->session->active)) &&
@@ -852,207 +1362,31 @@ int lttngh_EventProbe(
                  caa_unlikely(EventProbeFilter(pEvent, pDataDesc, cDataDesc))))
             {
                 // Compute event size the first time through.
-                if (caa_likely(maxAlign == 0))
+                if (caa_likely(context.maxAlign == 0))
                 {
-                    maxAlign = 1;
-                    assert(cbData == 0);
-
-                    for (unsigned i = 0; i != cDataDesc; i += 1)
+                    err = EventProbeComputeSizes(&context, pDataDesc, cDataDesc);
+                    if (err != 0)
                     {
-                        switch (pDataDesc[i].Type)
-                        {
-                        case lttngh_DataType_StringUtf16Transcoded:
-                        case lttngh_DataType_StringUtf32Transcoded:
-                        {
-                            unsigned cbUtf8;
-
-                            if (pDataDesc[i].Type == lttngh_DataType_StringUtf16Transcoded)
-                            {
-                                unsigned cch16 = pDataDesc[i].Size / sizeof(char16_t);
-                                assert(cch16 != 0); // Error in caller - Size should have included NUL.
-                                cch16 -= 1;         // Do not count NUL.
-
-                                if (caa_unlikely(cch16 > 65535))
-                                {
-                                    if (cch16 == ~0u)
-                                    {
-                                        cch16 = 0; // Error in caller - Size was 0.
-                                    }
-                                    else
-                                    {
-                                        cch16 = 65535;
-                                    }
-                                }
-
-                                cbUtf8 = Utf16ToUtf8Size(pDataDesc[i].Data, cch16);
-                            }
-                            else
-                            {
-                                unsigned cch32 = pDataDesc[i].Size / sizeof(char32_t);
-                                assert(cch32 != 0); // Error in caller - Size should have included NUL.
-                                cch32 -= 1;         // Do not count NUL.
-
-                                if (caa_unlikely(cch32 > 65535))
-                                {
-                                    if (cch32 == ~0u)
-                                    {
-                                        cch32 = 0; // Error in caller - Size was 0.
-                                    }
-                                    else
-                                    {
-                                        cch32 = 65535;
-                                    }
-                                }
-
-                                cbUtf8 = Utf32ToUtf8Size(pDataDesc[i].Data, cch32);
-                            }
-
-                            if (caa_unlikely(cbUtf8 > 65535))
-                            {
-                                cbUtf8 = 65535;
-                            }
-
-                            // Use DataDesc.Length as scratch space to store utf-8 content size.
-                            pDataDesc[i].Length = (uint16_t)cbUtf8; // Does not count NUL.
-
-                            cbUtf8 += 1; // Include room for 8-bit NUL.
-                            if (caa_unlikely(cbTranscodeWanted < cbUtf8))
-                            {
-                                cbTranscodeWanted = cbUtf8;
-                            }
-
-                            cbData += cbUtf8;
-                            if (caa_unlikely(cbData < cbUtf8))
-                            {
-                                err = EOVERFLOW;
-                                goto Done;
-                            }
-                            break;
-                        }
-                        case lttngh_DataType_SequenceUtf16Transcoded:
-                        case lttngh_DataType_SequenceUtf32Transcoded:
-                        {
-#ifdef RING_BUFFER_ALIGN
-                            if (__alignof__(uint16_t) > maxAlign)
-                            {
-                                maxAlign = __alignof__(uint16_t);
-                            }
-
-                            unsigned const alignAdjust =
-                                lib_ring_buffer_align(cbData, __alignof__(uint16_t));
-                            cbData += alignAdjust;
-                            if (caa_unlikely(cbData < alignAdjust))
-                            {
-                                err = EOVERFLOW;
-                                goto Done;
-                            }
-#endif // RING_BUFFER_ALIGN
-
-                            unsigned cbUtf8;
-
-                            if (pDataDesc[i].Type == lttngh_DataType_SequenceUtf16Transcoded)
-                            {
-                                unsigned cch16 = pDataDesc[i].Size / sizeof(char16_t);
-                                if (caa_unlikely(cch16 > 65535))
-                                {
-                                    cch16 = 65535;
-                                }
-
-                                cbUtf8 = Utf16ToUtf8Size(pDataDesc[i].Data, cch16);
-                            }
-                            else
-                            {
-                                unsigned cch32 = pDataDesc[i].Size / sizeof(char32_t);
-                                if (caa_unlikely(cch32 > 65535))
-                                {
-                                    cch32 = 65535;
-                                }
-
-                                cbUtf8 = Utf32ToUtf8Size(pDataDesc[i].Data, cch32);
-                            }
-
-                            if (caa_unlikely(cbUtf8 > 65535))
-                            {
-                                cbUtf8 = 65535;
-                            }
-
-                            // Use DataDesc.Length as scratch space to store utf-8 content size.
-                            pDataDesc[i].Length = (uint16_t)cbUtf8;
-
-                            cbUtf8 += 2; // Include room for 16-bit length.
-                            if (caa_unlikely(cbTranscodeWanted < cbUtf8))
-                            {
-                                cbTranscodeWanted = cbUtf8;
-                            }
-
-                            cbData += cbUtf8;
-                            if (caa_unlikely(cbData < cbUtf8))
-                            {
-                                err = EOVERFLOW;
-                                goto Done;
-                            }
-                            break;
-                        }
-                        default:
-                        {
-#ifdef RING_BUFFER_ALIGN
-                            if (pDataDesc[i].Alignment > maxAlign)
-                            {
-                                maxAlign = pDataDesc[i].Alignment;
-                            }
-
-                            unsigned const alignAdjust =
-                                lib_ring_buffer_align(cbData, pDataDesc[i].Alignment);
-                            cbData += alignAdjust;
-                            if (caa_unlikely(cbData < alignAdjust))
-                            {
-                                err = EOVERFLOW;
-                                goto Done;
-                            }
-#endif // RING_BUFFER_ALIGN
-
-                            cbData += pDataDesc[i].Size;
-                            if (cbData < pDataDesc[i].Size)
-                            {
-                                err = EOVERFLOW;
-                                goto Done;
-                            }
-                            break;
-                        }
-                        }
-                    }
-
-                    // If our scratch buffer is too small, try to heap allocate.
-                    if (caa_unlikely(cbTranscodeScratch < cbTranscodeWanted))
-                    {
-                        unsigned char *pbTranscodeWanted = (unsigned char *)malloc(cbTranscodeWanted);
-                        if (caa_unlikely(pbTranscodeWanted == NULL))
-                        {
-                            err = ENOMEM;
-                            goto Done;
-                        }
-
-                        cbTranscodeScratch = cbTranscodeWanted;
-                        pbTranscodeScratch = pbTranscodeWanted;
+                        goto Done;
                     }
                 }
 
-#ifndef USE_LTTNG_2_7
+#if lttngh_UST_VER >= 208
                 struct lttng_stack_ctx stackContext;
                 memset(&stackContext, 0, sizeof(stackContext));
 
                 stackContext.event = pEvent;
-                stackContext.chan_ctx = lttngh_RCU_DEREFERENCE(pChannel->ctx);
-                stackContext.event_ctx = lttngh_RCU_DEREFERENCE(pEvent->ctx);
-#endif
+                stackContext.chan_ctx = lttng_ust_rcu_dereference(pChannel->ctx);
+                stackContext.event_ctx = lttng_ust_rcu_dereference(pEvent->ctx);
+#endif // lttngh_UST_VER >= 208
 
                 struct lttng_ust_lib_ring_buffer_ctx bufferContext;
                 lib_ring_buffer_ctx_init(&bufferContext, pChannel->chan, pEvent,
-                                         cbData, (int)maxAlign, -1, pChannel->handle
-#ifndef USE_LTTNG_2_7
+                    context.cbData, (int)context.maxAlign, -1, pChannel->handle
+#if lttngh_UST_VER >= 208
                                          ,
                                          &stackContext
-#endif
+#endif // lttngh_UST_VER >= 208
                 );
                 bufferContext.ip = pCallerIp;
 
@@ -1063,15 +1397,16 @@ int lttngh_EventProbe(
                 }
                 else
                 {
-                    for (unsigned i = 0; i != cDataDesc; i += 1)
+                    unsigned i;
+                    for (i = 0; i != cDataDesc; i += 1)
                     {
-#ifdef RING_BUFFER_ALIGN
+                        uint16_t cbUtf8Written;
+#if lttngh_UST_RING_BUFFER_NATURAL_ALIGN
                         lib_ring_buffer_align_ctx(&bufferContext, pDataDesc[i].Alignment);
-#endif // RING_BUFFER_ALIGN
+#endif // lttngh_UST_RING_BUFFER_NATURAL_ALIGN
                         switch (pDataDesc[i].Type)
                         {
                         case lttngh_DataType_String8:
-                        {
                             if (pChannel->ops->u.has_strcpy)
                             {
                                 pChannel->ops->event_strcpy(&bufferContext, pDataDesc[i].Data, pDataDesc[i].Size);
@@ -1081,94 +1416,39 @@ int lttngh_EventProbe(
                                 pChannel->ops->event_write(&bufferContext, pDataDesc[i].Data, pDataDesc[i].Size);
                             }
                             break;
-                        }
+
                         case lttngh_DataType_StringUtf16Transcoded:
                         case lttngh_DataType_StringUtf32Transcoded:
-                        {
-                            assert(pDataDesc[i].Length <= cbTranscodeScratch - 1);
-
-                            uint16_t cbUtf8Written;
-                            if (pDataDesc[i].Type == lttngh_DataType_StringUtf16Transcoded)
-                            {
-                                cbUtf8Written = (uint16_t)Utf16ToUtf8(
-                                    pDataDesc[i].Data, pDataDesc[i].Size / sizeof(char16_t),
-                                    pbTranscodeScratch, pDataDesc[i].Length);
-                            }
-                            else
-                            {
-                                cbUtf8Written = (uint16_t)Utf32ToUtf8(
-                                    pDataDesc[i].Data, pDataDesc[i].Size / sizeof(char32_t),
-                                    pbTranscodeScratch, pDataDesc[i].Length);
-                            }
-
-                            pbTranscodeScratch[cbUtf8Written] = 0;
-                            size_t iNul = strlen((char *)pbTranscodeScratch);
-                            if (caa_unlikely(iNul != pDataDesc[i].Length))
-                            {
-                                // The data was changed on another thread or was truncated at a multi-byte char, so append #s.
-                                assert(iNul <= cbUtf8Written);
-                                assert(cbUtf8Written < pDataDesc[i].Length);
-                                memset(pbTranscodeScratch + iNul,
-                                       '#', pDataDesc[i].Length - iNul);
-                                pbTranscodeScratch[pDataDesc[i].Length] = 0;
-                            }
-
-                            pChannel->ops->event_write(&bufferContext, pbTranscodeScratch, cbUtf8Written + 1u);
+                            cbUtf8Written = EventProbeTranscodeString(&context, &pDataDesc[i]);
+                            pChannel->ops->event_write(&bufferContext, context.pbTranscodeScratch, cbUtf8Written + 1u);
                             break;
-                        }
+
                         case lttngh_DataType_SequenceUtf16Transcoded:
                         case lttngh_DataType_SequenceUtf32Transcoded:
-                        {
-                            assert(pDataDesc[i].Length <= cbTranscodeScratch - sizeof(uint16_t));
-
-                            uint16_t cbUtf8Written;
-                            if (pDataDesc[i].Type == lttngh_DataType_SequenceUtf16Transcoded)
-                            {
-                                cbUtf8Written = (uint16_t)Utf16ToUtf8(
-                                    pDataDesc[i].Data, pDataDesc[i].Size / sizeof(char16_t),
-                                    pbTranscodeScratch + sizeof(uint16_t), pDataDesc[i].Length);
-                            }
-                            else
-                            {
-                                cbUtf8Written = (uint16_t)Utf32ToUtf8(
-                                    pDataDesc[i].Data, pDataDesc[i].Size / sizeof(char32_t),
-                                    pbTranscodeScratch + sizeof(uint16_t), pDataDesc[i].Length);
-                            }
-
-                            if (caa_unlikely(cbUtf8Written != pDataDesc[i].Length))
-                            {
-                                // The data was changed on another thread or was truncated at a multi-byte char, so append #s.
-                                assert(cbUtf8Written < pDataDesc[i].Length);
-                                memset(pbTranscodeScratch + sizeof(uint16_t) + cbUtf8Written,
-                                       '#', pDataDesc[i].Length - (unsigned)cbUtf8Written);
-                                cbUtf8Written = pDataDesc[i].Length;
-                            }
-
-                            memcpy(pbTranscodeScratch, &cbUtf8Written, sizeof(uint16_t)); // Fill in length.
-                            pChannel->ops->event_write(&bufferContext, pbTranscodeScratch, sizeof(uint16_t) + cbUtf8Written);
+                            cbUtf8Written = EventProbeTranscodeSequence(&context, &pDataDesc[i]);
+                            pChannel->ops->event_write(&bufferContext, context.pbTranscodeScratch, sizeof(uint16_t) + cbUtf8Written);
                             break;
-                        }
+
                         default:
-                        {
                             pChannel->ops->event_write(&bufferContext, pDataDesc[i].Data, pDataDesc[i].Size);
                             break;
-                        }
                         }
                     }
 
                     pChannel->ops->event_commit(&bufferContext);
                 }
             }
+#endif // lttngh_UST_VER
         } while ((++pTpProbe)->data);
     }
 
 Done:
 
-    tp_rcu_read_unlock_bp();
+    lttng_ust_urcu_read_unlock();
 
-    if (caa_unlikely(pbTranscodeScratch != transcodeScratchOnStack))
+    if (caa_unlikely(context.pbTranscodeScratch != transcodeScratchOnStack))
     {
-        free(pbTranscodeScratch);
+        free(context.pbTranscodeScratch);
     }
 
     return err;

--- a/src/LttngHelpers.c
+++ b/src/LttngHelpers.c
@@ -83,8 +83,8 @@ const struct lttng_ust_type_sequence lttngh_TypeHexInt64Sequence = lttngh_INIT_T
 //const struct lttng_ust_type_sequence lttngh_TypeFloat32Sequence = lttngh_INIT_TYPE_SEQUENCE(lttngh_TypeFloat32, NULL, lttngh_ALIGNOF(float));
 //const struct lttng_ust_type_sequence lttngh_TypeFloat64Sequence = lttngh_INIT_TYPE_SEQUENCE(lttngh_TypeFloat64, NULL, lttngh_ALIGNOF(double));
 
-const struct lttng_ust_type_sequence lttngh_TypeBool8Sequence  = lttngh_INIT_TYPE_SEQUENCE(lttngh_TypeUInt8, NULL, lttngh_ALIGNOF(int8_t));
-const struct lttng_ust_type_sequence lttngh_TypeBool32Sequence = lttngh_INIT_TYPE_SEQUENCE(lttngh_TypeInt32, NULL, lttngh_ALIGNOF(int32_t));
+//const struct lttng_ust_type_sequence lttngh_TypeBool8Sequence  = lttngh_INIT_TYPE_SEQUENCE(lttngh_TypeBool8ForArray, NULL, lttngh_ALIGNOF(int8_t));
+//const struct lttng_ust_type_sequence lttngh_TypeBool32Sequence = lttngh_INIT_TYPE_SEQUENCE(lttngh_TypeBool32ForArray, NULL, lttngh_ALIGNOF(int32_t));
 
 const struct lttng_ust_type_string   lttngh_TypeUtf8String   = lttngh_INIT_TYPE_CHAR8_STRING(UTF8);
 const struct lttng_ust_type_sequence lttngh_TypeUtf8Sequence = lttngh_INIT_TYPE_CHAR8_SEQUENCE(UTF8, NULL);
@@ -597,9 +597,14 @@ static int EventProbeFilter(
         case lttngh_DataType_String8:
         case lttngh_DataType_StringUtf16Transcoded:
         case lttngh_DataType_StringUtf32Transcoded:
+#if lttngh_UST_VER >= 213
+        case lttngh_DataType_Counted:
+#endif
             cbBuffer += (unsigned)sizeof(void *);
             break;
+#if lttngh_UST_VER < 213
         case lttngh_DataType_Counted:
+#endif
         case lttngh_DataType_SequenceUtf16Transcoded:
         case lttngh_DataType_SequenceUtf32Transcoded:
             cbBuffer += (unsigned)(sizeof(unsigned long) + sizeof(void *));
@@ -881,12 +886,16 @@ static int EventProbeFilter(
             case lttngh_DataType_String8:
             case lttngh_DataType_StringUtf16Transcoded:
             case lttngh_DataType_StringUtf32Transcoded:
+#if lttngh_UST_VER >= 213
+            case lttngh_DataType_Counted:
+#endif
             {
                 // TODO - convert to utf8 for filtering?
                 memcpy(pStackData, &pDataDesc[i].Data, sizeof(void *));
                 pStackData += sizeof(void *);
                 break;
             }
+#if lttngh_UST_VER < 213
             case lttngh_DataType_Counted:
             {
                 unsigned long len = pDataDesc[i].Length;
@@ -896,6 +905,7 @@ static int EventProbeFilter(
                 pStackData += sizeof(void *);
                 break;
             }
+#endif // lttngh_UST_VER
             case lttngh_DataType_SequenceUtf16Transcoded:
             case lttngh_DataType_SequenceUtf32Transcoded:
             {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,12 +6,10 @@ add_executable(
     TestTraceLogging.cpp
     TestTraceLogging.c)
 
-# FIXME: lttng-ust-common only for 2.13 and later.
-# (Should be handled by the LTTngUST package?)
+# FIXME: For LTTNG 2.13+, also needs lttng-ust-common
 target_link_libraries(
     traceloggingTest
     PRIVATE
-    lttng-ust-common
     tracelogging
     Catch2::Catch2)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,8 +1,19 @@
 cmake_minimum_required(VERSION 3.5)
 
-# Add source to this project's executable.
-add_executable(traceloggingTest CatchMain.cpp TestTraceLogging.cpp)
-target_link_libraries(traceloggingTest PRIVATE tracelogging Catch2::Catch2)
+add_executable(
+    traceloggingTest
+    CatchMain.cpp
+    TestTraceLogging.cpp
+    TestTraceLogging.c)
+
+# FIXME: lttng-ust-common only for 2.13 and later.
+# (Should be handled by the LTTngUST package?)
+target_link_libraries(
+    traceloggingTest
+    PRIVATE
+    lttng-ust-common
+    tracelogging
+    Catch2::Catch2)
 
 include(CTest)
 include(Catch)

--- a/test/TestTraceLogging.c
+++ b/test/TestTraceLogging.c
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <tracelogging/TraceLoggingProvider.h>
+
+TRACELOGGING_DECLARE_PROVIDER(TestProviderC);
+#define TestProvider TestProviderC
+#include "TestTraceLogging.h"
+
+TRACELOGGING_DEFINE_PROVIDER(
+    TestProviderC,
+    "TestProviderC",
+    // {0da7a945-e9b1-510f-0ccf-ab1af0bc095b}
+    (0x0da7a945, 0xe9b1, 0x510f, 0x0c, 0xcf, 0xab, 0x1a, 0xf0, 0xbc, 0x09, 0x5b));
+
+#include <stdio.h>
+
+bool TestC()
+{
+    int err;
+    err = TraceLoggingRegister(TestProvider);
+    printf("TestC register: %d\n", err);
+    printf("Name: %s\n", TraceLoggingProviderName(TestProvider));
+    TraceLoggingWrite(TestProvider, "Event1");
+    printf("Enabled1: %d\n", TraceLoggingEventEnabled(TestProvider, "Event1"));
+    TraceLoggingWrite(TestProvider, "Event2", TraceLoggingKeyword(3));
+    printf("Enabled2: %d\n", TraceLoggingEventEnabled(TestProvider, "Event2"));
+    bool ok = TestCommon() && err == 0;
+    err = TraceLoggingUnregister(TestProvider);
+    printf("TestC unregister: %d\n", err);
+    return ok && err == 0;
+}

--- a/test/TestTraceLogging.cpp
+++ b/test/TestTraceLogging.cpp
@@ -1,20 +1,127 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include <catch2/catch.hpp>
 #include <tracelogging/TraceLoggingProvider.h>
 
-TRACELOGGING_DEFINE_PROVIDER(g_testProvider, "MyTestProvider",
-                             (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0));
+TRACELOGGING_DECLARE_PROVIDER(TestProviderCpp);
+#define TestProvider TestProviderCpp
+#include "TestTraceLogging.h"
+
+TRACELOGGING_DEFINE_PROVIDER(
+    TestProviderCpp,
+    "TestProviderCpp",
+    // {3f3dc547-92d7-59d6-ed26-053336a36f9b}
+    (0x3f3dc547, 0x92d7, 0x59d6, 0xed, 0x26, 0x05, 0x33, 0x36, 0xa3, 0x6f, 0x9b));
+
+static bool TestTraceLoggingValue()
+{
+    void const* const pSamplePtr = (void*)(intptr_t)(-12345);
+
+    TraceLoggingWrite(TestProvider, "Value:bool",
+        TraceLoggingValue(false),
+        TraceLoggingValue(true));
+    TraceLoggingWrite(TestProvider, "Value:char",
+        TraceLoggingValue('\0', "0"),
+        TraceLoggingValue('A', "A"));
+    TraceLoggingWrite(TestProvider, "Value:char16",
+        TraceLoggingValue(u'\0', "0"),
+        TraceLoggingValue(u'A', "A"));
+    TraceLoggingWrite(TestProvider, "Value:char32",
+        TraceLoggingValue(U'\0', "0"),
+        TraceLoggingValue(U'A', "A"));
+    TraceLoggingWrite(TestProvider, "Value:wchar",
+        TraceLoggingValue(L'\0', "0"),
+        TraceLoggingValue(L'A', "A"));
+    TraceLoggingWrite(TestProvider, "Value:schar",
+        TraceLoggingValue((signed char)0, "0"),
+        TraceLoggingValue((signed char)L'A', "A"));
+    TraceLoggingWrite(TestProvider, "Value:uchar",
+        TraceLoggingValue((unsigned char)0, "0"),
+        TraceLoggingValue((unsigned char)L'A', "A"));
+    TraceLoggingWrite(TestProvider, "Value:sshort",
+        TraceLoggingValue((signed short)0, "0"),
+        TraceLoggingValue((signed short)L'A', "A"));
+    TraceLoggingWrite(TestProvider, "Value:ushort",
+        TraceLoggingValue((unsigned short)0, "0"),
+        TraceLoggingValue((unsigned short)L'A', "A"));
+    TraceLoggingWrite(TestProvider, "Value:sint",
+        TraceLoggingValue((signed int)0, "0"),
+        TraceLoggingValue((signed int)L'A', "A"));
+    TraceLoggingWrite(TestProvider, "Value:uint",
+        TraceLoggingValue((unsigned int)0, "0"),
+        TraceLoggingValue((unsigned int)L'A', "A"));
+    TraceLoggingWrite(TestProvider, "Value:slong",
+        TraceLoggingValue((signed long)0, "0"),
+        TraceLoggingValue((signed long)L'A', "A"));
+    TraceLoggingWrite(TestProvider, "Value:ulong",
+        TraceLoggingValue((unsigned long)0, "0"),
+        TraceLoggingValue((unsigned long)L'A', "A"));
+    TraceLoggingWrite(TestProvider, "Value:slonglong",
+        TraceLoggingValue((signed long long)0, "0"),
+        TraceLoggingValue((signed long long)L'A', "A"));
+    TraceLoggingWrite(TestProvider, "Value:ulonglong",
+        TraceLoggingValue((unsigned long long)0, "0"),
+        TraceLoggingValue((unsigned long long)L'A', "A"));
+    TraceLoggingWrite(TestProvider, "Value:float",
+        TraceLoggingValue(0.0f, "0"),
+        TraceLoggingValue(65.0f, "65"));
+    TraceLoggingWrite(TestProvider, "Value:double",
+        TraceLoggingValue(0.0, "0"),
+        TraceLoggingValue(65.0, "65"));
+    TraceLoggingWrite(TestProvider, "Value:void*",
+        TraceLoggingValue((void*)0, "0"),
+        TraceLoggingValue((void*)pSamplePtr, "p"));
+    TraceLoggingWrite(TestProvider, "Value:cvoid*",
+        TraceLoggingValue((void const*)0, "0"),
+        TraceLoggingValue((void const*)pSamplePtr, "p"));
+    TraceLoggingWrite(TestProvider, "Value:char*",
+        TraceLoggingValue((char*)0, "0"),
+        TraceLoggingValue((char*)"hello", "hello"));
+    TraceLoggingWrite(TestProvider, "Value:cchar*",
+        TraceLoggingValue((char const*)0, "0"),
+        TraceLoggingValue((char const*)"hello", "hello"));
+    TraceLoggingWrite(TestProvider, "Value:char16_t*",
+        TraceLoggingValue((char16_t*)0, "0"),
+        TraceLoggingValue((char16_t*)u"hello", "hello"));
+    TraceLoggingWrite(TestProvider, "Value:cchar16_t*",
+        TraceLoggingValue((char16_t const*)0, "0"),
+        TraceLoggingValue((char16_t const*)u"hello", "hello"));
+    TraceLoggingWrite(TestProvider, "Value:char32_t*",
+        TraceLoggingValue((char32_t*)0, "0"),
+        TraceLoggingValue((char32_t*)U"hello", "hello"));
+    TraceLoggingWrite(TestProvider, "Value:cchar32_t*",
+        TraceLoggingValue((char32_t const*)0, "0"),
+        TraceLoggingValue((char32_t const*)U"hello", "hello"));
+    TraceLoggingWrite(TestProvider, "Value:wchar_t*",
+        TraceLoggingValue((wchar_t*)0, "0"),
+        TraceLoggingValue((wchar_t*)L"hello", "hello"));
+    TraceLoggingWrite(TestProvider, "Value:cwchar_t*",
+        TraceLoggingValue((wchar_t const*)0, "0"),
+        TraceLoggingValue((wchar_t const*)L"hello", "hello"));
+    return true;
+}
+
+#include <stdio.h>
+
+bool TestCpp()
+{
+    int err;
+    err = TraceLoggingRegister(TestProvider);
+    printf("TestCpp register: %d\n", err);
+    printf("Name: %s\n", TraceLoggingProviderName(TestProvider));
+    TraceLoggingWrite(TestProvider, "Event1");
+    printf("Enabled1: %d\n", TraceLoggingEventEnabled(TestProvider, "Event1"));
+    TraceLoggingWrite(TestProvider, "Event2", TraceLoggingKeyword(3));
+    printf("Enabled2: %d\n", TraceLoggingEventEnabled(TestProvider, "Event2"));
+    bool ok = TestCommon() && TestTraceLoggingValue() && err == 0;
+    err = TraceLoggingUnregister(TestProvider);
+    printf("TestCpp unregister: %d\n", err);
+    return ok && err == 0;
+}
+
+#include <catch2/catch.hpp>
 
 TEST_CASE("TraceLogging workflow builds", "[tracelogging]") {
-  TraceLoggingRegister(g_testProvider);
-
-  int x = 0;
-  TraceLoggingWrite(g_testProvider, "MyEventName",
-                    TraceLoggingValue(x, "XVal"));
-
-  TraceLoggingUnregister(g_testProvider);
-
-  REQUIRE(true == true);
+  REQUIRE(TestC());
+  REQUIRE(TestCpp());
 }

--- a/test/TestTraceLogging.h
+++ b/test/TestTraceLogging.h
@@ -1,0 +1,288 @@
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+    bool TestC(void);
+    bool TestCpp(void);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+typedef struct Buffer
+{
+    void* Buffer;
+    uint16_t Length;
+} Buffer;
+
+static bool TestCommon(void)
+{
+    const bool b0 = 0;
+    const bool b1 = 1;
+    const uint8_t b8 = 1;
+    const int32_t b32 = 1;
+    const int8_t i8 = 100;
+    const uint8_t u8 = 200;
+    const int16_t i16 = 30000;
+    const uint16_t u16 = 60000;
+    const int32_t i32 = 2000000000;
+    const uint32_t u32 = 4000000000;
+    const long iL = 2000000000;
+    const unsigned long uL = 4000000000;
+    const int64_t i64 = 9000000000000000000;
+    const uint64_t u64 = 18000000000000000000u;
+    const float f32 = 3.14f;
+    const double f64 = 6.28;
+    const char ch = 'A';
+    const char16_t u16ch = u'A';
+    const char32_t u32ch = U'A';
+    const wchar_t wch = L'B';
+    const intptr_t iptr = 1234;
+    const uintptr_t uptr = 4321;
+    const uint32_t ft[] = { 10000, 20000 };
+    const uint16_t st[] = { 45, 1, 2, 3, 4, 0, 0, 0 };
+    char ch10[10] = "HowAreU8?";
+    char16_t u16ch10[10] = u"HowAreU16";
+    char32_t u32ch10[10] = U"HowAreU32";
+    wchar_t wch10[10] = L"Goodbye!!";
+    uint8_t const guid[16] = { 1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8};
+    void const* const pSamplePtr = (void*)(intptr_t)(-12345);
+    Buffer buf = { ch10, 4 };
+    unsigned short n1 = 1;
+    unsigned short n5 = 5;
+
+    TraceLoggingWrite(TestProvider, "CScalars1");
+    TraceLoggingWrite(
+        TestProvider,
+        "CScalars2",
+        TraceLoggingLevel(1),
+        TraceLoggingKeyword(0x5),
+        TraceLoggingOpcode(2));
+    TraceLoggingWrite(
+        TestProvider,
+        "CScalars3",
+        TraceLoggingLevel(2),
+        TraceLoggingKeyword(0x80),
+        TraceLoggingOpcode(3),
+        TraceLoggingLevel(4),
+        TraceLoggingKeyword(0x05),
+        TraceLoggingChannel(11),
+        TraceLoggingEventTag(0x1234),
+        TraceLoggingDescription("Hello"),
+        TraceLoggingCustomAttribute("custom", "attribute"),
+        TraceLoggingStruct(1, "IgnoredStruct"),
+            TraceLoggingInt32(1));
+
+    uint8_t oldActivityId[16];
+    lttngh_ActivityIdGet(oldActivityId);
+    uint8_t activityId[16];
+    lttngh_ActivityIdCreate(activityId);
+    TraceLoggingWrite(TestProvider, "ThreadActivity0");
+    lttngh_ActivityIdSet(guid);
+    TraceLoggingWrite(TestProvider, "ThreadActivity1");
+    lttngh_ActivityIdSet(oldActivityId);
+    TraceLoggingWrite(TestProvider, "ThreadActivity2");
+    TraceLoggingWriteActivity(TestProvider, "Transfer00", NULL, NULL);
+    TraceLoggingWriteActivity(TestProvider, "Transfer01", NULL, guid);
+    TraceLoggingWriteActivity(TestProvider, "Transfer10", guid, NULL);
+    TraceLoggingWriteActivity(TestProvider, "Transfer11", guid, guid);
+    TraceLoggingWriteActivity(TestProvider, "TransferOO", oldActivityId, oldActivityId);
+
+    TraceLoggingWrite(TestProvider, "i8", TraceLoggingInt8(i8));
+    TraceLoggingWrite(TestProvider, "u8", TraceLoggingUInt8(u8));
+    TraceLoggingWrite(TestProvider, "i16", TraceLoggingInt16(i16));
+    TraceLoggingWrite(TestProvider, "u16", TraceLoggingUInt16(u16));
+    TraceLoggingWrite(TestProvider, "i32", TraceLoggingInt32(i32));
+    TraceLoggingWrite(TestProvider, "u32", TraceLoggingUInt32(u32));
+    TraceLoggingWrite(TestProvider, "iL", TraceLoggingLong(iL));
+    TraceLoggingWrite(TestProvider, "uL", TraceLoggingULong(uL));
+    TraceLoggingWrite(TestProvider, "i64", TraceLoggingInt64(i64));
+    TraceLoggingWrite(TestProvider, "u64", TraceLoggingUInt64(u64));
+
+    TraceLoggingWrite(TestProvider, "hi8",  TraceLoggingHexInt8(i8));
+    TraceLoggingWrite(TestProvider, "hu8",  TraceLoggingHexUInt8(u8));
+    TraceLoggingWrite(TestProvider, "hi16", TraceLoggingHexInt16(i16));
+    TraceLoggingWrite(TestProvider, "hu16", TraceLoggingHexUInt16(u16));
+    TraceLoggingWrite(TestProvider, "hi32", TraceLoggingHexInt32(i32));
+    TraceLoggingWrite(TestProvider, "hu32", TraceLoggingHexUInt32(u32));
+    TraceLoggingWrite(TestProvider, "hiL",  TraceLoggingHexLong(iL));
+    TraceLoggingWrite(TestProvider, "huL",  TraceLoggingHexULong(uL));
+    TraceLoggingWrite(TestProvider, "hi64", TraceLoggingHexInt64(i64));
+    TraceLoggingWrite(TestProvider, "hu64", TraceLoggingHexUInt64(u64));
+
+    TraceLoggingWrite(TestProvider, "iptr", TraceLoggingIntPtr(iptr));
+    TraceLoggingWrite(TestProvider, "uptr", TraceLoggingUIntPtr(uptr));
+    TraceLoggingWrite(TestProvider, "f32", TraceLoggingFloat32(f32));
+    TraceLoggingWrite(TestProvider, "f64", TraceLoggingFloat64(f64));
+    TraceLoggingWrite(TestProvider, "b8", TraceLoggingBoolean(b0), TraceLoggingBoolean(b1));
+    TraceLoggingWrite(TestProvider, "b32", TraceLoggingBool(b0), TraceLoggingBool(b1));
+
+    TraceLoggingWrite(TestProvider, "ch", TraceLoggingChar(ch));
+    TraceLoggingWrite(TestProvider, "wch", TraceLoggingWChar(wch));
+    TraceLoggingWrite(TestProvider, "u16ch", TraceLoggingChar16(u16ch));
+    TraceLoggingWrite(TestProvider, "u32ch", TraceLoggingChar16(u32ch));
+    TraceLoggingWrite(TestProvider, "ptr", TraceLoggingPointer(pSamplePtr));
+    TraceLoggingWrite(TestProvider, "cptr", TraceLoggingCodePointer(pSamplePtr));
+    TraceLoggingWrite(TestProvider, "pid", TraceLoggingPid(u32));
+    TraceLoggingWrite(TestProvider, "tid", TraceLoggingTid(u32));
+    TraceLoggingWrite(TestProvider, "port", TraceLoggingPort(80));
+    TraceLoggingWrite(TestProvider, "winerror", TraceLoggingWinError(u32));
+    TraceLoggingWrite(TestProvider, "ntstatus", TraceLoggingNTStatus(u32));
+    TraceLoggingWrite(TestProvider, "hresult", TraceLoggingHResult(u32));
+
+    TraceLoggingWrite(TestProvider, "guid", TraceLoggingGuid(guid));
+    TraceLoggingWrite(TestProvider, "st", TraceLoggingSystemTime(st));
+    TraceLoggingWrite(TestProvider, "ust", TraceLoggingSystemTimeUtc(st));
+    TraceLoggingWrite(TestProvider, "ft", TraceLoggingFileTime(ft));
+    TraceLoggingWrite(TestProvider, "uft", TraceLoggingFileTimeUtc(ft));
+
+    TraceLoggingWrite(TestProvider, "sz",
+        TraceLoggingString(NULL, "NULL"),
+        TraceLoggingString(ch10));
+    TraceLoggingWrite(TestProvider, "sz8",
+        TraceLoggingUtf8String(NULL, "NULL"),
+        TraceLoggingUtf8String(ch10));
+    TraceLoggingWrite(TestProvider, "wsz",
+        TraceLoggingWideString(NULL, "NULL"),
+        TraceLoggingWideString(wch10));
+    TraceLoggingWrite(TestProvider, "sz16",
+        TraceLoggingString16(NULL, "NULL"),
+        TraceLoggingString16(u16ch10));
+    TraceLoggingWrite(TestProvider, "sz32",
+        TraceLoggingString32(NULL, "NULL"),
+        TraceLoggingString32(u32ch10));
+
+    TraceLoggingWrite(TestProvider, "csz",
+        TraceLoggingCountedString(NULL, 0, "NULL"),
+        TraceLoggingCountedString(ch10, 5));
+    TraceLoggingWrite(TestProvider, "csz8",
+        TraceLoggingCountedUtf8String(NULL, 0, "NULL"),
+        TraceLoggingCountedUtf8String(ch10, 5));
+    TraceLoggingWrite(TestProvider, "cwsz",
+        TraceLoggingCountedWideString(NULL, 0, "NULL"),
+        TraceLoggingCountedWideString(wch10, 5));
+    TraceLoggingWrite(TestProvider, "csz16",
+        TraceLoggingCountedString16(NULL, 0, "NULL"),
+        TraceLoggingCountedString16(u16ch10, 5));
+    TraceLoggingWrite(TestProvider, "csz32",
+        TraceLoggingCountedString32(NULL, 0, "NULL"),
+        TraceLoggingCountedString32(u32ch10, 5));
+
+    TraceLoggingWrite(TestProvider, "bin",
+        TraceLoggingBinary(NULL, 0, "NULL"),
+        TraceLoggingBinary(ch10, 5),
+        TraceLoggingBinaryBuffer(&buf, Buffer, "buf"));
+
+    TraceLoggingWrite(TestProvider, "ai8",
+        TraceLoggingInt8FixedArray(&i8, 1, "a1"),
+        TraceLoggingInt8Array(&i8, n1, "s"));
+    TraceLoggingWrite(TestProvider, "au8",
+        TraceLoggingUInt8FixedArray(&u8, 1, "a1"),
+        TraceLoggingUInt8Array(&u8, n1, "s"));
+    TraceLoggingWrite(TestProvider, "ai16",
+        TraceLoggingInt16FixedArray(&i16, 1, "a1"),
+        TraceLoggingInt16Array(&i16, n1, "s"));
+    TraceLoggingWrite(TestProvider, "au16",
+        TraceLoggingUInt16FixedArray(&u16, 1, "a1"),
+        TraceLoggingUInt16Array(&u16, n1, "s"));
+    TraceLoggingWrite(TestProvider, "ai32",
+        TraceLoggingInt32FixedArray(&i32, 1, "a1"),
+        TraceLoggingInt32Array(&i32, n1, "s"));
+    TraceLoggingWrite(TestProvider, "au32",
+        TraceLoggingUInt32FixedArray(&u32, 1, "a1"),
+        TraceLoggingUInt32Array(&u32, n1, "s"));
+    TraceLoggingWrite(TestProvider, "aiL",
+        TraceLoggingLongFixedArray(&iL, 1, "a1"),
+        TraceLoggingLongArray(&iL, n1, "s"));
+    TraceLoggingWrite(TestProvider, "auL",
+        TraceLoggingULongFixedArray(&uL, 1, "a1"),
+        TraceLoggingULongArray(&uL, n1, "s"));
+    TraceLoggingWrite(TestProvider, "ai64",
+        TraceLoggingInt64FixedArray(&i64, 1, "a1"),
+        TraceLoggingInt64Array(&i64, n1, "s"));
+    TraceLoggingWrite(TestProvider, "au64",
+        TraceLoggingUInt64FixedArray(&u64, 1, "a1"),
+        TraceLoggingUInt64Array(&u64, n1, "s"));
+
+    TraceLoggingWrite(TestProvider, "hai8",
+        TraceLoggingHexInt8FixedArray(&i8, 1, "a1"),
+        TraceLoggingHexInt8Array(&i8, n1, "s"));
+    TraceLoggingWrite(TestProvider, "hau8",
+        TraceLoggingHexUInt8FixedArray(&u8, 1, "a1"),
+        TraceLoggingHexUInt8Array(&u8, n1, "s"));
+    TraceLoggingWrite(TestProvider, "hai16",
+        TraceLoggingHexInt16FixedArray(&i16, 1, "a1"),
+        TraceLoggingHexInt16Array(&i16, n1, "s"));
+    TraceLoggingWrite(TestProvider, "hau16",
+        TraceLoggingHexUInt16FixedArray(&u16, 1, "a1"),
+        TraceLoggingHexUInt16Array(&u16, n1, "s"));
+    TraceLoggingWrite(TestProvider, "hai32",
+        TraceLoggingHexInt32FixedArray(&i32, 1, "a1"),
+        TraceLoggingHexInt32Array(&i32, n1, "s"));
+    TraceLoggingWrite(TestProvider, "hau32",
+        TraceLoggingHexUInt32FixedArray(&u32, 1, "a1"),
+        TraceLoggingHexUInt32Array(&u32, n1, "s"));
+    TraceLoggingWrite(TestProvider, "haiL",
+        TraceLoggingHexLongFixedArray(&iL, 1, "a1"),
+        TraceLoggingHexLongArray(&iL, n1, "s"));
+    TraceLoggingWrite(TestProvider, "hauL",
+        TraceLoggingHexULongFixedArray(&uL, 1, "a1"),
+        TraceLoggingHexULongArray(&uL, n1, "s"));
+    TraceLoggingWrite(TestProvider, "hai64",
+        TraceLoggingHexInt64FixedArray(&i64, 1, "a1"),
+        TraceLoggingHexInt64Array(&i64, n1, "s"));
+    TraceLoggingWrite(TestProvider, "hau64",
+        TraceLoggingHexUInt64FixedArray(&u64, 1, "a1"),
+        TraceLoggingHexUInt64Array(&u64, n1, "s"));
+
+    TraceLoggingWrite(TestProvider, "aiptr",
+        TraceLoggingIntPtrFixedArray(&iptr, 1, "a1"),
+        TraceLoggingIntPtrArray(&iptr, n1, "s"));
+    TraceLoggingWrite(TestProvider, "auptr",
+        TraceLoggingUIntPtrFixedArray(&uptr, 1, "a1"),
+        TraceLoggingUIntPtrArray(&uptr, n1, "s"));
+    TraceLoggingWrite(TestProvider, "ab32",
+        TraceLoggingBoolFixedArray(&b32, 1, "a1"),
+        TraceLoggingBoolArray(&b32, n1, "s"));
+    TraceLoggingWrite(TestProvider, "ab8",
+        TraceLoggingBooleanFixedArray(&b8, 1, "a1"),
+        TraceLoggingBooleanArray(&b8, n1, "s"));
+
+    TraceLoggingWrite(TestProvider, "ach",
+        TraceLoggingCharFixedArray(ch10, 4, "a4"),
+        TraceLoggingCharArray(ch10, n5, "s5"));
+    TraceLoggingWrite(TestProvider, "awch",
+        TraceLoggingWCharFixedArray(wch10, 4, "a4"),
+        TraceLoggingWCharArray(wch10, n5, "s5"));
+    TraceLoggingWrite(TestProvider, "ach16",
+        TraceLoggingChar16FixedArray(u16ch10, 4, "a4"),
+        TraceLoggingChar16Array(u16ch10, n5, "s5"));
+    TraceLoggingWrite(TestProvider, "ach32",
+        TraceLoggingChar32FixedArray(u32ch10, 4, "a4"),
+        TraceLoggingChar32Array(u32ch10, n5, "s5"));
+
+    TraceLoggingWrite(TestProvider, "aptr",
+        TraceLoggingPointerFixedArray(&pSamplePtr, 1, "a1"),
+        TraceLoggingPointerArray(&pSamplePtr, n1, "s"));
+    TraceLoggingWrite(TestProvider, "acptr",
+        TraceLoggingCodePointerFixedArray(&pSamplePtr, 1, "a1"),
+        TraceLoggingCodePointerArray(&pSamplePtr, n1, "s"));
+
+    TraceLoggingWrite(TestProvider, "aguid",
+        TraceLoggingGuidFixedArray(guid, 1, "a1"),
+        TraceLoggingGuidArray(guid, n1, "s"));
+    TraceLoggingWrite(TestProvider, "ast",
+        TraceLoggingSystemTimeFixedArray(st, 1, "a1"),
+        TraceLoggingSystemTimeArray(st, n1, "s"));
+    TraceLoggingWrite(TestProvider, "aust",
+        TraceLoggingSystemTimeUtcFixedArray(st, 1, "a1"),
+        TraceLoggingSystemTimeUtcArray(st, n1, "s"));
+    TraceLoggingWrite(TestProvider, "aft",
+        TraceLoggingFileTimeFixedArray(ft, 1, "a1"),
+        TraceLoggingFileTimeArray(ft, n1, "s"));
+    TraceLoggingWrite(TestProvider, "auft",
+        TraceLoggingFileTimeUtcFixedArray(ft, 1, "a1"),
+        TraceLoggingFileTimeUtcArray(ft, n1, "s"));
+
+    return true;
+}


### PR DESCRIPTION
lttng-ust 2.13 is a major breaking change and requires significant
updates to the LttngHelpers and TraceLoggingProvider libraries.

OPEN ISSUE:
- CMake's LTTngUST package is not picking up the new lttng-ust-common
  library. For now, if building 2.13+, you must edit CMakeLists.txt to add it.

Overview of changes in LTTNG-UST 2.13:
- Many LTTng symbols were renamed.
- Sequence no longer includes the length field. Instead, the sequence
  field references the length field by name.
- Most of the structs are now designed to be versionable, i.e. they start
  with a size.
- The lttng_type field has been split into separate structs, which are
  related via C-style inheritance (shared initial field which is a
  discriminator enum value).
- The field descriptor now stores an `lttng_type_common*` by reference
  instead of storing an `lttng_type` by value.
- In cases of a 1-to-many relationship, the parent struct now generally has
  pointer-to-array-of-pointer-to-struct (`const struct foo* const*`), not
  pointer-to-array-of-struct (`const struct foo*`) as before.

Verified that LTTNG 2.10 and 2.13 build and produce the same output.

README.md:
- Fix some typos and some confusing descriptions.

LttngHelpers.h:
- Add an abstraction layer to simplify working with both pre-2.13 and
  post-2.13 LTTng.
- Note that if your code consumes LttngHelpers.h and targets 2.08..2.12, the
  code should continue to work without any changes. However, if your
  code targets 2.07 and directly references lttngh_BoolEnumDesc, it will
  need fixes (your code was broken anyway). And if your code wants to
  target 2.13, it will need to switch to use the abstraction layer (and
  will still have a few ifdefs based on `lttngh_UST_VER`).

TraceLoggingProvider.h:
- Switch to using the new abstraction layer. Mostly this means passing
  around "UstType" macro parameters (provided by LttngHelpers.h) instead
  of composing the UstTypes ourselves. (We still have to compose the array
  types.)
- Add support for 2.13. (Look for `lttngh_UST_VER`.)
- Add support for using a macro for `providerSymbol` in
  TraceLoggingWrite.
- Converting char16/char32 into "sequence of utf8" is a bit problematic
  since 2.13 considers a sequence to be 2 fields, so instead we now convert
  char16/char32 into "nul-terminated utf8 string".
- A few minor bits of cleanup.

LttngHelpers.c:
- In 2.13, provide predefined UstType constants for the precomposed
  types (covers all common cases except fixed-length arrays).
- Use adaptation layer where appropriate.
- Add support for 2.13. (Look for `lttngh_UST_VER`.)
- Refactor to extract subroutines so that the version-specific
  alternatives are easier to follow.

test\CMakeLists.txt:
- Add more tests, run against both C and C++.
- 2.13 requires linking against new lttng-ust-common library. For some
  reason, CMake's LTTngUST doesn't pick this up, so it must be added
  manually before building against 2.13. (FIXME)