### PR TITLE
Log strings for IPv4, IPv6, sockaddr

### DIFF
--- a/include/lttngh/LttngHelpers.h
+++ b/include/lttngh/LttngHelpers.h
@@ -697,6 +697,28 @@ int lttngh_EventProbe(struct lttng_ust_tracepoint *pTracepoint,
     __attribute__((noinline)) lttng_ust_notrace;
 
 /*
+Formats a 4-byte IPv4 address as a nul-terminated string.
+Output buffer is assumed to be at least 16 chars.
+*/
+void lttngh_FormatIPv4(const void* pIPv4, char* buf16) lttng_ust_notrace;
+#define LTTNGH_FORMAT_IPV4_LEN 16u // Buffer length for lttngh_FormatIPv4.
+
+/*
+Formats a 16-byte IPv6 address as a nul-terminated string.
+Output buffer is assumed to be at least 46 chars.
+*/
+void lttngh_FormatIPv6(const void* pIPv6, char* buf46) lttng_ust_notrace;
+#define LTTNGH_FORMAT_IPV6_LEN 46u // Buffer length for lttngh_FormatIPv6.
+
+/*
+Formats a sockaddr as a nul-terminated string.
+Output buffer is assumed to be at least 65 chars.
+*/
+void lttngh_FormatSockaddr(const void* pSockaddr, unsigned cbSockaddr,
+                           char* buf65) lttng_ust_notrace;
+#define LTTNGH_FORMAT_SOCKADDR_LEN 65u // Buffer length for lttngh_FormatSockaddr.
+
+/*
 For use by code that is starting an activity.
 Generates a new 16-byte activity ID and copies it to pActivityId.
 Note that while the generated ID has the structure of a GUID, it is not

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,7 +3,10 @@ cmake_minimum_required(VERSION 3.5)
 set(TLG_INCLUDEDIR ${PROJECT_SOURCE_DIR}/include/)
 
 # Add source to this project's executable.
-add_library(lttngh LttngActivityHelpers.c LttngHelpers.c)
+add_library(lttngh
+    LttngActivityHelpers.c
+    LttngHelpers.c
+    LttngNetHelpers.c)
 
 target_compile_features(lttngh PRIVATE c_std_99)
 

--- a/src/LttngActivityHelpers.c
+++ b/src/LttngActivityHelpers.c
@@ -5,8 +5,8 @@
 #define _POSIX_C_SOURCE 199309L
 #endif
 
-#include <byteswap.h> // bswap_32, BYTE_ORDER
 #include <lttngh/LttngHelpers.h>
+#include <byteswap.h> // bswap_32, BYTE_ORDER
 #include <time.h>   // clock_gettime
 #include <unistd.h> // getpid
 

--- a/src/LttngNetHelpers.c
+++ b/src/LttngNetHelpers.c
@@ -28,7 +28,7 @@ void lttngh_FormatSockaddr(const void* pSockaddr, unsigned cbSockaddr,
 {
     static unsigned const SizeOfInet4ThroughAddr = offsetof(struct sockaddr_in, sin_zero);
     static unsigned const SizeOfInet6ThroughAddr = offsetof(struct sockaddr_in6, sin6_scope_id);
-    static unsigned const SizeOfInet6ThroughScope = SizeOfInet6ThroughAddr + 4;
+    static unsigned const SizeOfInet6ThroughScope = offsetof(struct sockaddr_in6, sin6_scope_id) + sizeof(uint32_t);
     static unsigned const MaxHexDigits = LTTNGH_FORMAT_SOCKADDR_LEN - sizeof("0x");
     char* pOut = buf65;
     unsigned i, cb;

--- a/src/LttngNetHelpers.c
+++ b/src/LttngNetHelpers.c
@@ -26,9 +26,10 @@ void lttngh_FormatIPv6(const void* pIPv6, char* buf46)
 void lttngh_FormatSockaddr(const void* pSockaddr, unsigned cbSockaddr,
                            char* buf65)
 {
-    unsigned const SizeOfInet4ThroughAddr = offsetof(struct sockaddr_in, sin_zero);
-    unsigned const SizeOfInet6ThroughAddr = offsetof(struct sockaddr_in6, sin6_scope_id);
-    unsigned const SizeOfInet6ThroughScope = SizeOfInet6ThroughAddr + 4;
+    static unsigned const SizeOfInet4ThroughAddr = offsetof(struct sockaddr_in, sin_zero);
+    static unsigned const SizeOfInet6ThroughAddr = offsetof(struct sockaddr_in6, sin6_scope_id);
+    static unsigned const SizeOfInet6ThroughScope = SizeOfInet6ThroughAddr + 4;
+    static unsigned const MaxHexDigits = LTTNGH_FORMAT_SOCKADDR_LEN - sizeof("0x");
     char* pOut = buf65;
     unsigned i, cb;
 
@@ -90,7 +91,9 @@ void lttngh_FormatSockaddr(const void* pSockaddr, unsigned cbSockaddr,
 
     *pOut++ = '0';
     *pOut++ = 'x';
-    cb = cbSockaddr < 31 ? cbSockaddr : 31;
+    *pOut = 0;
+
+    cb = cbSockaddr < (MaxHexDigits / 2) ? cbSockaddr : (MaxHexDigits / 2);
     for (i = 0; i != cb; i += 1)
     {
         sprintf(pOut, "%02X", ((unsigned char const*)pSockaddr)[i]);

--- a/src/LttngNetHelpers.c
+++ b/src/LttngNetHelpers.c
@@ -1,0 +1,104 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#ifndef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 199309L
+#endif
+
+#include <lttngh/LttngHelpers.h>
+#include <arpa/inet.h>
+#include <stdio.h> // sprintf
+
+void lttngh_FormatIPv4(const void* pIPv4, char* buf16)
+{
+    inet_ntop(AF_INET, pIPv4, buf16, LTTNGH_FORMAT_IPV4_LEN);
+    assert(strlen(buf16) < LTTNGH_FORMAT_IPV4_LEN);
+    buf16[LTTNGH_FORMAT_IPV4_LEN - 1] = 0;
+}
+
+void lttngh_FormatIPv6(const void* pIPv6, char* buf46)
+{
+    inet_ntop(AF_INET6, pIPv6, buf46, LTTNGH_FORMAT_IPV6_LEN);
+    assert(strlen(buf46) < LTTNGH_FORMAT_IPV6_LEN);
+    buf46[LTTNGH_FORMAT_IPV6_LEN - 1] = 0;
+}
+
+void lttngh_FormatSockaddr(const void* pSockaddr, unsigned cbSockaddr,
+                           char* buf65)
+{
+    unsigned const SizeOfInet4ThroughAddr = offsetof(struct sockaddr_in, sin_zero);
+    unsigned const SizeOfInet6ThroughAddr = offsetof(struct sockaddr_in6, sin6_scope_id);
+    unsigned const SizeOfInet6ThroughScope = SizeOfInet6ThroughAddr + 4;
+    char* pOut = buf65;
+    unsigned i, cb;
+
+    if (cbSockaddr >= 2)
+    {
+        switch (((struct sockaddr const*)pSockaddr)->sa_family)
+        {
+        case AF_INET:
+
+            if (cbSockaddr >= SizeOfInet4ThroughAddr)
+            {
+                struct sockaddr_in const* const pSock = (struct sockaddr_in const*)pSockaddr;
+                lttngh_FormatIPv4(&pSock->sin_addr, pOut);
+
+                if (pSock->sin_port != 0)
+                {
+                    pOut += strlen(pOut);
+                    sprintf(pOut, ":%u",
+                        ntohs(pSock->sin_port));
+                }
+
+                goto Done;
+            }
+            break;
+
+        case AF_INET6:
+
+            if (cbSockaddr >= SizeOfInet6ThroughAddr)
+            {
+                struct sockaddr_in6 const* const pSock = (struct sockaddr_in6 const*)pSockaddr;
+
+                if (pSock->sin6_port != 0)
+                {
+                    *pOut++ = '[';
+                }
+
+                lttngh_FormatIPv6(&pSock->sin6_addr, pOut);
+
+                if (cbSockaddr >= SizeOfInet6ThroughScope &&
+                    pSock->sin6_scope_id != 0)
+                {
+                    pOut += strlen(pOut);
+                    sprintf(pOut, "%%%u",
+                        ntohl(pSock->sin6_scope_id));
+                }
+
+                if (pSock->sin6_port != 0)
+                {
+                    pOut += strlen(pOut);
+                    sprintf(pOut, "]:%u",
+                        ntohs(pSock->sin6_port));
+                }
+
+                goto Done;
+            }
+            break;
+        }
+    }
+
+    *pOut++ = '0';
+    *pOut++ = 'x';
+    cb = cbSockaddr < 31 ? cbSockaddr : 31;
+    for (i = 0; i != cb; i += 1)
+    {
+        sprintf(pOut, "%02X", ((unsigned char const*)pSockaddr)[i]);
+        pOut += 2;
+    }
+
+Done:
+
+    assert(strlen(buf65) < LTTNGH_FORMAT_SOCKADDR_LEN);
+    buf65[LTTNGH_FORMAT_SOCKADDR_LEN - 1] = 0;
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,11 +6,11 @@ add_executable(
     TestTraceLogging.cpp
     TestTraceLogging.c)
 
-# FIXME: For LTTNG 2.13+, also needs lttng-ust-common
 target_link_libraries(
     traceloggingTest
     PRIVATE
     tracelogging
+    # lttng-ust-common # Needed for LTTNG 2.13+
     Catch2::Catch2)
 
 include(CTest)

--- a/test/TestTraceLogging.h
+++ b/test/TestTraceLogging.h
@@ -156,6 +156,8 @@ static bool TestCommon(void)
     TraceLoggingWrite(TestProvider, "ipV6", TraceLoggingIPv6(&ipv6, "ipv6"), TraceLoggingChar(ch));
     TraceLoggingWrite(TestProvider, "saV4", TraceLoggingSocketAddress(&saIPv4, sizeof(saIPv4), "saV4"), TraceLoggingChar(ch));
     TraceLoggingWrite(TestProvider, "saV6", TraceLoggingSocketAddress(&saIPv6, sizeof(saIPv6), "saV6"), TraceLoggingChar(ch));
+    TraceLoggingWrite(TestProvider, "saEmpty", TraceLoggingSocketAddress("", 0, "empty"), TraceLoggingChar(ch));
+    TraceLoggingWrite(TestProvider, "saGarbage", TraceLoggingSocketAddress("ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789", 36, "garbage"), TraceLoggingChar(ch));
     TraceLoggingWrite(TestProvider, "winerror", TraceLoggingWinError(u32));
     TraceLoggingWrite(TestProvider, "ntstatus", TraceLoggingNTStatus(u32));
     TraceLoggingWrite(TestProvider, "hresult", TraceLoggingHResult(u32));

--- a/test/TestTraceLogging.h
+++ b/test/TestTraceLogging.h
@@ -1,3 +1,5 @@
+#include <arpa/inet.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -50,6 +52,30 @@ static bool TestCommon(void)
     Buffer buf = { ch10, 4 };
     unsigned short n1 = 1;
     unsigned short n5 = 5;
+    const uint16_t port80 = htons(80);
+
+    const uint8_t ipv4data[] = { 127, 0, 0, 1 };
+    in_addr_t ipv4;
+    memcpy(&ipv4, ipv4data, sizeof(ipv4));
+
+    const uint8_t ipv6data[] = { 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16 };
+    struct in6_addr ipv6;
+    memcpy(&ipv6, ipv6data, sizeof(ipv6));
+
+    const struct sockaddr_in saIPv4 = {
+        .sin_family = AF_INET,
+        .sin_port = port80,
+        .sin_addr = { ipv4 },
+        .sin_zero = { 0 }
+    };
+
+    const struct sockaddr_in6 saIPv6 = {
+        .sin6_family = AF_INET6,
+        .sin6_port = port80,
+        .sin6_flowinfo = 5,
+        .sin6_addr = ipv6,
+        .sin6_scope_id = htonl(1234)
+    };
 
     TraceLoggingWrite(TestProvider, "CScalars1");
     TraceLoggingWrite(
@@ -125,7 +151,11 @@ static bool TestCommon(void)
     TraceLoggingWrite(TestProvider, "cptr", TraceLoggingCodePointer(pSamplePtr));
     TraceLoggingWrite(TestProvider, "pid", TraceLoggingPid(u32));
     TraceLoggingWrite(TestProvider, "tid", TraceLoggingTid(u32));
-    TraceLoggingWrite(TestProvider, "port", TraceLoggingPort(80));
+    TraceLoggingWrite(TestProvider, "port", TraceLoggingPort(port80));
+    TraceLoggingWrite(TestProvider, "ipV4", TraceLoggingIPv4(ipv4), TraceLoggingChar(ch));
+    TraceLoggingWrite(TestProvider, "ipV6", TraceLoggingIPv6(&ipv6, "ipv6"), TraceLoggingChar(ch));
+    TraceLoggingWrite(TestProvider, "saV4", TraceLoggingSocketAddress(&saIPv4, sizeof(saIPv4), "saV4"), TraceLoggingChar(ch));
+    TraceLoggingWrite(TestProvider, "saV6", TraceLoggingSocketAddress(&saIPv6, sizeof(saIPv6), "saV6"), TraceLoggingChar(ch));
     TraceLoggingWrite(TestProvider, "winerror", TraceLoggingWinError(u32));
     TraceLoggingWrite(TestProvider, "ntstatus", TraceLoggingNTStatus(u32));
     TraceLoggingWrite(TestProvider, "hresult", TraceLoggingHResult(u32));


### PR DESCRIPTION
LTTNG does not have native types for IPv4 addresses, IPv6 addresses, or
sockaddr. Add indirect support - these objects will be converted to
strings before being added to the trace.

- Add LttngHelpers APIs to format these types.
- Add TraceLoggingProvider.h support for these types, including new
  macros for IPv4 and IPv6.
- Add tests.