### PR TITLE
Fixing LTTng version issues and adding `liblttng-ust-common.so` for LTTng 2.13+

### DIFF
--- a/cmake/modules/FindLTTngUST.cmake
+++ b/cmake/modules/FindLTTngUST.cmake
@@ -1,0 +1,112 @@
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+#[=======================================================================[.rst:
+FindLTTngUST
+------------
+
+.. versionadded:: 3.6
+
+Find
+`Linux Trace Toolkit Next Generation (LTTng-UST) <http://lttng.org/>`__ library.
+
+Imported target
+^^^^^^^^^^^^^^^
+
+This module defines the following :prop_tgt:`IMPORTED` target:
+
+``LTTng::UST``
+  The LTTng-UST library, if found
+
+Result variables
+^^^^^^^^^^^^^^^^
+
+This module sets the following
+
+``LTTNGUST_FOUND``
+  ``TRUE`` if system has LTTng-UST
+``LTTNGUST_INCLUDE_DIRS``
+  The LTTng-UST include directories
+``LTTNGUST_LIBRARIES``
+  The libraries needed to use LTTng-UST
+``LTTNGUST_VERSION_STRING``
+  The LTTng-UST version
+``LTTNGUST_HAS_TRACEF``
+  ``TRUE`` if the ``tracef()`` API is available in the system's LTTng-UST
+``LTTNGUST_HAS_TRACELOG``
+  ``TRUE`` if the ``tracelog()`` API is available in the system's LTTng-UST
+#]=======================================================================]
+
+find_path(LTTNGUST_INCLUDE_DIRS NAMES lttng/tracepoint.h)
+find_library(LTTNGUST_LIBRARIES NAMES lttng-ust)
+
+find_library(LTTNG_UST_COMMON_LIBRARIES NAMES lttng-ust-common)
+
+if(LTTNGUST_INCLUDE_DIRS AND LTTNGUST_LIBRARIES)
+  # find tracef() and tracelog() support
+  set(LTTNGUST_HAS_TRACEF 0)
+  set(LTTNGUST_HAS_TRACELOG 0)
+
+  if(EXISTS "${LTTNGUST_INCLUDE_DIRS}/lttng/tracef.h")
+    set(LTTNGUST_HAS_TRACEF TRUE)
+  endif()
+
+  if(EXISTS "${LTTNGUST_INCLUDE_DIRS}/lttng/tracelog.h")
+    set(LTTNGUST_HAS_TRACELOG TRUE)
+  endif()
+
+  # get version
+  set(lttngust_version_file "${LTTNGUST_INCLUDE_DIRS}/lttng/ust-version.h")
+
+  if(EXISTS "${lttngust_version_file}")
+    file(STRINGS "${lttngust_version_file}" lttngust_version_major_string
+         REGEX "^[\t ]*#define[\t ]+LTTNG_UST_MAJOR_VERSION[\t ]+[0-9]+[\t ]*$")
+    file(STRINGS "${lttngust_version_file}" lttngust_version_minor_string
+         REGEX "^[\t ]*#define[\t ]+LTTNG_UST_MINOR_VERSION[\t ]+[0-9]+[\t ]*$")
+    file(STRINGS "${lttngust_version_file}" lttngust_version_patch_string
+         REGEX "^[\t ]*#define[\t ]+LTTNG_UST_PATCHLEVEL_VERSION[\t ]+[0-9]+[\t ]*$")
+    string(REGEX REPLACE ".*[\t ]+([0-9]+).*" "\\1"
+           lttngust_v_major "${lttngust_version_major_string}")
+    string(REGEX REPLACE ".*[\t ]+([0-9]+).*" "\\1"
+           lttngust_v_minor "${lttngust_version_minor_string}")
+    string(REGEX REPLACE ".*[\t ]+([0-9]+).*" "\\1"
+           lttngust_v_patch "${lttngust_version_patch_string}")
+    set(LTTNGUST_VERSION_STRING
+        "${lttngust_v_major}.${lttngust_v_minor}.${lttngust_v_patch}")
+    unset(lttngust_version_major_string)
+    unset(lttngust_version_minor_string)
+    unset(lttngust_version_patch_string)
+    unset(lttngust_v_major)
+    unset(lttngust_v_minor)
+    unset(lttngust_v_patch)
+  endif()
+
+  unset(lttngust_version_file)
+
+  # add libdl to required libraries
+    if (${LTTNGUST_VERSION_STRING} VERSION_GREATER_EQUAL "2.13")
+        set(LTTNGUST_LINK_LIBRARIES ${LTTNG_UST_COMMON_LIBRARIES} ${CMAKE_DL_LIBS})
+    else()
+        set(LTTNGUST_LINK_LIBRARIES ${CMAKE_DL_LIBS})
+    endif()
+
+  if(NOT TARGET LTTng::UST)
+    add_library(LTTng::UST UNKNOWN IMPORTED)
+    set_target_properties(LTTng::UST PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "${LTTNGUST_INCLUDE_DIRS}"
+      INTERFACE_LINK_LIBRARIES "${LTTNGUST_LINK_LIBRARIES}"
+      IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+      IMPORTED_LOCATION "${LTTNGUST_LIBRARIES}")
+  endif()
+
+# add libdl to required libraries
+set(LTTNGUST_LIBRARIES ${LTTNGUST_LIBRARIES} ${LTTNGUST_LINK_LIBRARIES})
+
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(LTTngUST FOUND_VAR LTTNGUST_FOUND
+                                  REQUIRED_VARS LTTNGUST_LIBRARIES
+                                                LTTNGUST_INCLUDE_DIRS
+                                  VERSION_VAR LTTNGUST_VERSION_STRING)
+mark_as_advanced(LTTNGUST_LIBRARIES LTTNGUST_INCLUDE_DIRS)

--- a/src/LttngHelpers.c
+++ b/src/LttngHelpers.c
@@ -102,10 +102,7 @@ extern int lttng_ust_tracepoint_module_unregister(struct lttng_ust_tracepoint* c
 #define lttngh_ust_tracepoint_module_register   lttng_ust_tracepoint_module_register
 #define lttngh_ust_tracepoint_module_unregister lttng_ust_tracepoint_module_unregister
 
-extern unsigned int lttng_ust_ring_buffer_align(size_t align_drift, size_t size_of_type);
-extern void lttng_ust_ring_buffer_align_ctx(struct lttng_ust_ring_buffer_ctx *ctx, size_t alignment);
-#define lttng_ust_ring_buffer_align lttng_ust_ring_buffer_align
-#define lttng_ust_ring_buffer_align_ctx lttng_ust_ring_buffer_align_ctx
+#define lttngh_ust_ring_buffer_align lttng_ust_ring_buffer_align
 
 #else // lttngh_UST_VER
 
@@ -135,10 +132,8 @@ extern int tracepoint_unregister_lib(struct lttng_ust_tracepoint* const* tracepo
 #define lttngh_ust_tracepoint_module_register   tracepoint_register_lib
 #define lttngh_ust_tracepoint_module_unregister tracepoint_unregister_lib
 
-extern unsigned int lib_ring_buffer_align(size_t align_drift, size_t size_of_type);
-extern void lib_ring_buffer_align_ctx(struct lttng_ust_lib_ring_buffer_ctx *ctx, size_t alignment);
-#define lttng_ust_ring_buffer_align lib_ring_buffer_align
-#define lttng_ust_ring_buffer_align_ctx lib_ring_buffer_align_ctx
+#define lttngh_ust_ring_buffer_align lib_ring_buffer_align
+#define lttngh_ust_ring_buffer_align_ctx lib_ring_buffer_align_ctx
 
 #endif // lttngh_UST_VER
 
@@ -1080,7 +1075,7 @@ static int EventProbeComputeSizes(
             }
 
             unsigned const alignAdjust =
-                lttng_ust_ring_buffer_align(pContext->cbData, __alignof__(uint16_t));
+                lttngh_ust_ring_buffer_align(pContext->cbData, __alignof__(uint16_t));
             pContext->cbData += alignAdjust;
             if (caa_unlikely(pContext->cbData < alignAdjust))
             {
@@ -1141,7 +1136,7 @@ static int EventProbeComputeSizes(
             }
 
             unsigned const alignAdjust =
-                lttng_ust_ring_buffer_align(pContext->cbData, pDataDesc[i].Alignment);
+                lttngh_ust_ring_buffer_align(pContext->cbData, pDataDesc[i].Alignment);
             pContext->cbData += alignAdjust;
             if (caa_unlikely(pContext->cbData < alignAdjust))
             {
@@ -1424,7 +1419,7 @@ int lttngh_EventProbe(
                     {
                         uint16_t cbUtf8Written;
 #if lttngh_UST_RING_BUFFER_NATURAL_ALIGN
-                        lttng_ust_ring_buffer_align_ctx(&bufferContext, pDataDesc[i].Alignment);
+                        lttngh_ust_ring_buffer_align_ctx(&bufferContext, pDataDesc[i].Alignment);
 #endif // lttngh_UST_RING_BUFFER_NATURAL_ALIGN
                         switch (pDataDesc[i].Type)
                         {

--- a/src/LttngHelpers.c
+++ b/src/LttngHelpers.c
@@ -102,6 +102,11 @@ extern int lttng_ust_tracepoint_module_unregister(struct lttng_ust_tracepoint* c
 #define lttngh_ust_tracepoint_module_register   lttng_ust_tracepoint_module_register
 #define lttngh_ust_tracepoint_module_unregister lttng_ust_tracepoint_module_unregister
 
+extern unsigned int lttng_ust_ring_buffer_align(size_t align_drift, size_t size_of_type);
+extern void lttng_ust_ring_buffer_align_ctx(struct lttng_ust_ring_buffer_ctx *ctx, size_t alignment);
+#define lttng_ust_ring_buffer_align lttng_ust_ring_buffer_align
+#define lttng_ust_ring_buffer_align_ctx lttng_ust_ring_buffer_align_ctx
+
 #else // lttngh_UST_VER
 
 #include <lttng/ringbuffer-config.h> // lttng_ust_lib_ring_buffer_ctx
@@ -129,6 +134,11 @@ extern int tracepoint_register_lib(struct lttng_ust_tracepoint* const* tracepoin
 extern int tracepoint_unregister_lib(struct lttng_ust_tracepoint* const* tracepoints_start);
 #define lttngh_ust_tracepoint_module_register   tracepoint_register_lib
 #define lttngh_ust_tracepoint_module_unregister tracepoint_unregister_lib
+
+extern unsigned int lib_ring_buffer_align(size_t align_drift, size_t size_of_type);
+extern void lib_ring_buffer_align_ctx(struct lttng_ust_lib_ring_buffer_ctx *ctx, size_t alignment);
+#define lttng_ust_ring_buffer_align lib_ring_buffer_align
+#define lttng_ust_ring_buffer_align_ctx lib_ring_buffer_align_ctx
 
 #endif // lttngh_UST_VER
 

--- a/src/LttngHelpers.c
+++ b/src/LttngHelpers.c
@@ -1070,7 +1070,7 @@ static int EventProbeComputeSizes(
             }
 
             unsigned const alignAdjust =
-                lib_ring_buffer_align(pContext->cbData, __alignof__(uint16_t));
+                lttng_ust_ring_buffer_align(pContext->cbData, __alignof__(uint16_t));
             pContext->cbData += alignAdjust;
             if (caa_unlikely(pContext->cbData < alignAdjust))
             {
@@ -1131,7 +1131,7 @@ static int EventProbeComputeSizes(
             }
 
             unsigned const alignAdjust =
-                lib_ring_buffer_align(pContext->cbData, pDataDesc[i].Alignment);
+                lttng_ust_ring_buffer_align(pContext->cbData, pDataDesc[i].Alignment);
             pContext->cbData += alignAdjust;
             if (caa_unlikely(pContext->cbData < alignAdjust))
             {
@@ -1414,7 +1414,7 @@ int lttngh_EventProbe(
                     {
                         uint16_t cbUtf8Written;
 #if lttngh_UST_RING_BUFFER_NATURAL_ALIGN
-                        lib_ring_buffer_align_ctx(&bufferContext, pDataDesc[i].Alignment);
+                        lttng_ust_ring_buffer_align_ctx(&bufferContext, pDataDesc[i].Alignment);
 #endif // lttngh_UST_RING_BUFFER_NATURAL_ALIGN
                         switch (pDataDesc[i].Type)
                         {


### PR DESCRIPTION
This PR makes the following changes: 

- Adds a local custom `FindLTTngUST.cmake`. 
    - This file contains the FindLTTngUST  version component extraction fix from https://github.com/Kitware/CMake/commit/4ce5765a8605cf4aa0fbb01f77ae2bf764452ccd.
    - Additionally it conditionally adds `liblttng-ust-common.so` to LTTngUST link libraries for LTTng 2.13+
- it switches `lib_ring_buffer_align*` calls to `lttng_ust_ring_buffer_align*`