### PR TITLE
LTTng: Document Inline Function Limitation

### DIFF
--- a/LTTng/README.md
+++ b/LTTng/README.md
@@ -72,6 +72,20 @@ lttng view
 
 For more information, see the [LTTng Documentation](https://lttng.org/docs/v2.10/).
 
+### Avoid Logging from Inline Functions
+
+This library uses a custom linker section to aid in the event registration process. Unfortunately, this technique can
+lead to issues such as compilation failure or unexpected runtime behavior when used in combination with inline
+functions.
+
+Because of this, you should avoid calling TraceLoggingWrite from within an inline function. This includes any function
+or method definition which appears _inside_ of a C++ class/struct definition (as these are implicitly inlined).
+
+For additional background regarding this problem, see [this Stack Overflow answer] as well as [this issue on the GCC Bugzilla].
+
+[this Stack Overflow Answer]: https://stackoverflow.com/questions/35091862/inline-static-data-causes-a-section-type-conflict/35441900#35441900
+[this issue on the GCC Bugzilla]: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=41091
+
 ## Dependencies
 
 This project depends on the lttng-ust library. To build this library, you will need liblttng-ust-dev version 2.10 or later.

--- a/LTTng/include/tracelogging/TraceLoggingProvider.h
+++ b/LTTng/include/tracelogging/TraceLoggingProvider.h
@@ -60,6 +60,8 @@ TraceLoggingProvider.h for LTTNG behaves differently from the ETW version:
   in TRACELOGGING_DEFINE_PROVIDER.
   - As a consequence of this, wil\TraceLogging.h will not work (no way to
     implement TRACELOGGING_DEFINE_PROVIDER_STORAGE).
+- TraceLoggingWrite and TraceLoggingWriteActivity should not be called from
+  within inline functions.
 - Limited support for TraceLoggingLevel.
   - You must use LTTNG level values, not ETW level values. For example,
     TraceLoggingLevel(4) means level="info" under ETW, but is level="warning"
@@ -420,6 +422,9 @@ Supports up to 99 args (subject to compiler limitations). Each arg must be a
 wrapper macro such as TraceLoggingLevel, TraceLoggingKeyword, TraceLoggingInt32,
 TraceLoggingString, etc.
 
+Should not be called from inside an inline function due to the way static variables
+and linker sections are manipulated.
+
 LTTNG-specific:
 - Total length of providerName + eventName must be less than 253.
 - The eventName must not contain any double-quote characters.
@@ -452,6 +457,9 @@ any '"' or '\0' characters.
 Supports up to 99 args (subject to compiler limitations). Each arg must be a
 wrapper macro such as TraceLoggingLevel, TraceLoggingKeyword, TraceLoggingInt32,
 TraceLoggingString, etc.
+
+Should not be called from inside an inline function due to the way static variables
+and linker sections are manipulated.
 
 LTTNG-specific:
 - Total length of providerName + eventName must be less than 253.


### PR DESCRIPTION
Add documentation to TraceLogging for LTTng which discourages its use from within inline functions.