### PR TITLE
Initial commit for vcpkg port

### DIFF
--- a/vcpkg/ports/tracelogging/portfile.cmake
+++ b/vcpkg/ports/tracelogging/portfile.cmake
@@ -1,0 +1,32 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO microsoft/tracelogging
+    REF v0.3.1
+    SHA512 8a34eb7d91b92c36fc0682d45c188361aaffd57b0b8bd62d16b876d3231fc96c5fe3369dc26d23ad2ca4eacda9ac565d04866c4b8b3be1214906c5f939d8a23a
+    HEAD_REF master
+)
+
+vcpkg_configure_cmake(
+	SOURCE_PATH "${SOURCE_PATH}"
+	PREFER_NINJA 
+
+    OPTIONS
+        -DTRACELOGGING_BUILD_TESTS=OFF
+        ${OPTIONS}
+)
+
+vcpkg_build_cmake()
+
+vcpkg_fixup_cmake_targets()
+
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+# ERROR: ${CURRENT_PACKAGES_DIR} = /opt/vcpkg/packages/tracelogging_x64-linux/debug/
+# when it should be /opt/vcpkg/packages/tracelogging_x64-linux/
+file(
+	INSTALL "${SOURCE_PATH}/LICENSE"
+	DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+	RENAME copyright)
+
+vcpkg_install_cmake()

--- a/vcpkg/ports/tracelogging/vcpkg.json
+++ b/vcpkg/ports/tracelogging/vcpkg.json
@@ -1,0 +1,6 @@
+{
+  "name": "tracelogging",
+  "version-string": "0.3.1",
+  "description": "TraceLogging is a set of technologies for emitting structured events. It is primarily used with Event Tracing for Windows (ETW). Some parts of TraceLogging are also available on other operating systems such as Linux with TraceLogging for LTTng.",
+  "homepage": "https://github.com/microsoft/tracelogging"
+}

--- a/vcpkg/versions/baseline.json
+++ b/vcpkg/versions/baseline.json
@@ -1,0 +1,8 @@
+{
+	"default": {
+		"tracelogging": {
+			"baseline": "0.3.1",
+			"port-version": 0
+		}
+	}
+}


### PR DESCRIPTION
TODO:

ERROR: _CMake Error at scripts/cmake/vcpkg_fixup_cmake_targets.cmake:81 (message):
  '/opt/vcpkg/packages/tracelogging_x64-linux/debug/share/tracelogging' does
  not exist._

ERROR: ${CURRENT_PACKAGES_DIR} = /opt/vcpkg/packages/tracelogging_x64-linux/debug/ when it should be /opt/vcpkg/packages/tracelogging_x64-linux/

Commenting out `vcpkg_fixup_cmake_targets()` makes it build, but shows the following warning: _Please use the helper function `vcpkg_cmake_config_fixup()` from the port vcpkg-cmake-config._
