### PR TITLE
Sometimes INET6_ADDRSTRLEN is 48

### DIFF
--- a/LTTng/include/lttngh/LttngHelpers.h
+++ b/LTTng/include/lttngh/LttngHelpers.h
@@ -705,10 +705,10 @@ void lttngh_FormatIPv4(const void* pIPv4, char* buf16) lttng_ust_notrace;
 
 /*
 Formats a 16-byte IPv6 address as a nul-terminated string.
-Output buffer is assumed to be at least 46 chars.
+Output buffer is assumed to be at least LTTNGH_FORMAT_IPV6_LEN chars.
 */
-void lttngh_FormatIPv6(const void* pIPv6, char* buf46) lttng_ust_notrace;
-#define LTTNGH_FORMAT_IPV6_LEN 46u // Buffer length for lttngh_FormatIPv6.
+void lttngh_FormatIPv6(const void* pIPv6, char* buf48) lttng_ust_notrace;
+#define LTTNGH_FORMAT_IPV6_LEN 48u // Buffer length for lttngh_FormatIPv6.
 
 /*
 Formats a sockaddr as a nul-terminated string.

--- a/LTTng/src/LttngNetHelpers.c
+++ b/LTTng/src/LttngNetHelpers.c
@@ -11,16 +11,18 @@
 
 void lttngh_FormatIPv4(const void* pIPv4, char* buf16)
 {
+    buf16[0] = 0;
     inet_ntop(AF_INET, pIPv4, buf16, LTTNGH_FORMAT_IPV4_LEN);
     assert(strlen(buf16) < LTTNGH_FORMAT_IPV4_LEN);
     buf16[LTTNGH_FORMAT_IPV4_LEN - 1] = 0;
 }
 
-void lttngh_FormatIPv6(const void* pIPv6, char* buf46)
+void lttngh_FormatIPv6(const void* pIPv6, char* buf48)
 {
-    inet_ntop(AF_INET6, pIPv6, buf46, LTTNGH_FORMAT_IPV6_LEN);
-    assert(strlen(buf46) < LTTNGH_FORMAT_IPV6_LEN);
-    buf46[LTTNGH_FORMAT_IPV6_LEN - 1] = 0;
+    buf48[0] = 0;
+    inet_ntop(AF_INET6, pIPv6, buf48, LTTNGH_FORMAT_IPV6_LEN);
+    assert(strlen(buf48) < LTTNGH_FORMAT_IPV6_LEN);
+    buf48[LTTNGH_FORMAT_IPV6_LEN - 1] = 0;
 }
 
 void lttngh_FormatSockaddr(const void* pSockaddr, unsigned cbSockaddr,


### PR DESCRIPTION
lttngh_FormatIPv6 requires a buffer of size 46, which is "max IPv6 format length". 46 matches the behavior of inet_ntop.

Nominally, our constant should match the value of `INET6_ADDRSTRLEN`, which is the commonly-used constant for "max IPv6 format length". Recent versions of Linux have increased the value to 48 to account for some formatters that add `[...]` around the address. So this PR updates the LTTNGH constant to match.

This isn't really necessary because inet_ntop doesn't add the `[...]` around the address, so it's max is still 46. But to avoid confusion, our constant should match.