### PR TITLE
rust: add filetime_from_systemtime macro

### DIFF
--- a/etw/rust/tracelogging/Cargo.toml
+++ b/etw/rust/tracelogging/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracelogging"
-version = "0.2.0"
+version = "1.0.1"
 edition = "2021"
 authors = ["Microsoft"]
 license = "MIT"
@@ -29,7 +29,7 @@ etw = [] # Logging is enabled if windows && etw.
 macros = ["dep:tracelogging_macros"]
 
 [dependencies]
-tracelogging_macros = { optional = true, version = "= 0.2.0", path = "../tracelogging_macros" }
+tracelogging_macros = { optional = true, version = "= 1.0.1", path = "../tracelogging_macros" }
 
 [dev-dependencies]
 windows = ">= 0.39"

--- a/etw/rust/tracelogging/Cargo.toml
+++ b/etw/rust/tracelogging/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracelogging"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["Microsoft"]
 license = "MIT"
@@ -29,7 +29,7 @@ etw = [] # Logging is enabled if windows && etw.
 macros = ["dep:tracelogging_macros"]
 
 [dependencies]
-tracelogging_macros = { optional = true, version = ">= 0.1.0", path = "../tracelogging_macros" }
+tracelogging_macros = { optional = true, version = "= 0.2.0", path = "../tracelogging_macros" }
 
 [dev-dependencies]
 windows = ">= 0.39"

--- a/etw/rust/tracelogging/src/lib.rs
+++ b/etw/rust/tracelogging/src/lib.rs
@@ -871,6 +871,21 @@ pub use native::NATIVE_IMPLEMENTATION;
 pub use provider::Provider;
 pub mod _internal;
 
+/// Converts a [std::time::SystemTime] into a Win32
+/// [FILETIME](https://learn.microsoft.com/en-us/windows/win32/api/minwinbase/ns-minwinbase-filetime)
+/// (represented as `i64`), suitable for use in a win_filetime field.
+#[macro_export]
+macro_rules! filetime_from_systemtime {
+    ($time:expr) => {
+        match $time.duration_since(::std::time::SystemTime::UNIX_EPOCH) {
+            Ok(dur) => ::tracelogging::_internal::filetime_from_duration_after_1970(dur),
+            Err(err) => {
+                ::tracelogging::_internal::filetime_from_duration_before_1970(err.duration())
+            }
+        }
+    };
+}
+
 mod descriptors;
 mod enums;
 mod guid;

--- a/etw/rust/tracelogging/src/native.rs
+++ b/etw/rust/tracelogging/src/native.rs
@@ -367,7 +367,7 @@ impl ProviderContextInner {
         filter_data: usize,
         outer_context: usize,
     ) {
-        (&mut *(outer_context as *mut Self)).outer_callback_impl(
+        (*(outer_context as *mut Self)).outer_callback_impl(
             source_id,
             event_control_code,
             level,

--- a/etw/rust/tracelogging/tests/tests.rs
+++ b/etw/rust/tracelogging/tests/tests.rs
@@ -161,14 +161,12 @@ fn tag_encode() {
 fn filetime_from_systemtime() {
     let epoch = std::time::SystemTime::UNIX_EPOCH;
     let d100 = std::time::Duration::from_secs(100);
-    let after = epoch + d100;
-    let before = epoch - d100;
     assert_eq!(
-        tlg::filetime_from_systemtime!(after),
+        tlg::filetime_from_systemtime!(epoch + d100),
         tli::filetime_from_duration_after_1970(d100)
     );
     assert_eq!(
-        tlg::filetime_from_systemtime!(before),
+        tlg::filetime_from_systemtime!(epoch - d100),
         tli::filetime_from_duration_before_1970(d100)
     );
 }

--- a/etw/rust/tracelogging_dynamic/Cargo.toml
+++ b/etw/rust/tracelogging_dynamic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracelogging_dynamic"
-version = "0.2.0"
+version = "1.0.1"
 edition = "2021"
 authors = ["Microsoft"]
 license = "MIT"
@@ -28,4 +28,4 @@ default = ["etw"]
 etw = ["tracelogging/etw"] # Logging is enabled if windows && etw.
 
 [dependencies]
-tracelogging = { default-features = false, version = "= 0.2.0", path = "../tracelogging" }
+tracelogging = { default-features = false, version = "= 1.0.1", path = "../tracelogging" }

--- a/etw/rust/tracelogging_dynamic/Cargo.toml
+++ b/etw/rust/tracelogging_dynamic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracelogging_dynamic"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["Microsoft"]
 license = "MIT"
@@ -28,4 +28,4 @@ default = ["etw"]
 etw = ["tracelogging/etw"] # Logging is enabled if windows && etw.
 
 [dependencies]
-tracelogging = { default-features = false, version = ">= 0.1.0", path = "../tracelogging" }
+tracelogging = { default-features = false, version = "= 0.2.0", path = "../tracelogging" }

--- a/etw/rust/tracelogging_dynamic/src/lib.rs
+++ b/etw/rust/tracelogging_dynamic/src/lib.rs
@@ -112,6 +112,7 @@
 //! ```
 
 // Re-exports from tracelogging:
+pub use tracelogging::filetime_from_systemtime;
 pub use tracelogging::Channel;
 pub use tracelogging::Guid;
 pub use tracelogging::InType;

--- a/etw/rust/tracelogging_dynamic/tests/tests.rs
+++ b/etw/rust/tracelogging_dynamic/tests/tests.rs
@@ -13,6 +13,11 @@ fn provider() {
         Guid::from_u128(&0xb7aa4d18_240c_5f41_5852_817dbf477472)
     );
 
+    assert_eq!(
+        filetime_from_systemtime!(std::time::SystemTime::UNIX_EPOCH),
+        0x19DB1DED53E8000
+    );
+
     let new_aid1 = Provider::create_activity_id();
     let new_aid2 = Provider::create_activity_id();
 

--- a/etw/rust/tracelogging_macros/Cargo.toml
+++ b/etw/rust/tracelogging_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracelogging_macros"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["Microsoft"]
 license = "MIT"

--- a/etw/rust/tracelogging_macros/Cargo.toml
+++ b/etw/rust/tracelogging_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracelogging_macros"
-version = "0.2.0"
+version = "1.0.1"
 edition = "2021"
 authors = ["Microsoft"]
 license = "MIT"

--- a/etw/rust/tracelogging_macros/src/event_generator.rs
+++ b/etw/rust/tracelogging_macros/src/event_generator.rs
@@ -494,32 +494,26 @@ impl EventGenerator {
                     )
                     .add_group_curly(
                         self.tree2
-                            // Ok(_tlg_dur) => filetime_from_duration_since_1970(_tlg_dur, true),
+                            // Ok(_tlg_dur) => filetime_from_duration_after_1970(_tlg_dur),
                             .add_path(RESULT_OK_PATH)
                             .add_group_paren(self.tree3.add_ident(TLG_DUR_VAR).drain())
                             .add_punct("=>")
                             .add_path_call(
-                                FILETIME_FROM_DURATION_PATH,
-                                self.tree3
-                                    .add_ident(TLG_DUR_VAR)
-                                    .add_punct(",")
-                                    .add_ident("true")
-                                    .drain(),
+                                FILETIME_FROM_DURATION_AFTER_PATH,
+                                self.tree3.add_ident(TLG_DUR_VAR).drain(),
                             )
                             .add_punct(",")
-                            // Err(_tlg_dur) => filetime_from_duration_since_1970(_tlg_dur.duration(), false),
+                            // Err(_tlg_dur) => filetime_from_duration_before_1970(_tlg_dur.duration()),
                             .add_path(RESULT_ERR_PATH)
                             .add_group_paren(self.tree3.add_ident(TLG_DUR_VAR).drain())
                             .add_punct("=>")
                             .add_path_call(
-                                FILETIME_FROM_DURATION_PATH,
+                                FILETIME_FROM_DURATION_BEFORE_PATH,
                                 self.tree3
                                     .add_ident(TLG_DUR_VAR)
                                     .add_punct(".")
                                     .add_ident("duration")
                                     .add_group_paren([])
-                                    .add_punct(",")
-                                    .add_ident("false")
                                     .drain(),
                             )
                             .add_punct(",")

--- a/etw/rust/tracelogging_macros/src/field_option.rs
+++ b/etw/rust/tracelogging_macros/src/field_option.rs
@@ -7,7 +7,7 @@ use crate::enums::{InType, OutType};
 pub enum FieldStrategy {
     /// meta = scalar; data = from_value
     Scalar,
-    /// meta = scalar; data = from_value(filetime_from_duration_since_1970)
+    /// meta = scalar; data = from_value(filetime_from_duration_***_1970)
     SystemTime,
     /// meta = scalar; data = from_sid
     Sid,

--- a/etw/rust/tracelogging_macros/src/strings.rs
+++ b/etw/rust/tracelogging_macros/src/strings.rs
@@ -154,10 +154,15 @@ pub const TAG_ENCODE_PATH: &[&str] = &["tracelogging", "_internal", "tag_encode"
 pub const TAG_SIZE_PATH: &[&str] = &["tracelogging", "_internal", "tag_size"];
 pub const COUNTED_SIZE_PATH: &[&str] = &["tracelogging", "_internal", "counted_size"];
 pub const SLICE_COUNT_PATH: &[&str] = &["tracelogging", "_internal", "slice_count"];
-pub const FILETIME_FROM_DURATION_PATH: &[&str] = &[
+pub const FILETIME_FROM_DURATION_AFTER_PATH: &[&str] = &[
     "tracelogging",
     "_internal",
-    "filetime_from_duration_since_1970",
+    "filetime_from_duration_after_1970",
+];
+pub const FILETIME_FROM_DURATION_BEFORE_PATH: &[&str] = &[
+    "tracelogging",
+    "_internal",
+    "filetime_from_duration_before_1970",
 ];
 
 pub const EVENTDESC_PATH: &[&str] = &["tracelogging", "_internal", "EventDescriptor"];


### PR DESCRIPTION
- Add a `filetime_from_systemtime!(systemTime)` macro. Export it from both tracelogging and from tracelogging_dynamic crates. Note that we're using a macro so that the tracelogging and tracelogging_dynamic crates do not become dependent on the `std` crate.
- As an optimization, split the `filetime_from_duration(dur, after)` function into two functions - one for after == true and one for after == false.