### PR TITLE
rust tracelogging - Debug trait, rename macro, fix docs

### DIFF
--- a/etw/rust/tracelogging/Cargo.toml
+++ b/etw/rust/tracelogging/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracelogging"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2021"
 authors = ["Microsoft"]
 license = "MIT"
@@ -29,7 +29,7 @@ etw = [] # Logging is enabled if windows && etw.
 macros = ["dep:tracelogging_macros"]
 
 [dependencies]
-tracelogging_macros = { optional = true, version = "= 1.0.1", path = "../tracelogging_macros" }
+tracelogging_macros = { optional = true, version = "= 1.0.2", path = "../tracelogging_macros" }
 
 [dev-dependencies]
 windows = ">= 0.39"

--- a/etw/rust/tracelogging/src/lib.rs
+++ b/etw/rust/tracelogging/src/lib.rs
@@ -871,11 +871,14 @@ pub use native::NATIVE_IMPLEMENTATION;
 pub use provider::Provider;
 pub mod _internal;
 
-/// Converts a [std::time::SystemTime] into a Win32
+/// Converts a
+/// [`std::time::SystemTime`](https://doc.rust-lang.org/std/time/struct.SystemTime.html)
+/// value into a Windows
 /// [FILETIME](https://learn.microsoft.com/en-us/windows/win32/api/minwinbase/ns-minwinbase-filetime)
-/// (represented as `i64`), suitable for use in a win_filetime field.
+/// (represented as `i64`). The resulting value can be used with
+/// [`write_event!`] via the `win_filetime` field type.
 #[macro_export]
-macro_rules! filetime_from_systemtime {
+macro_rules! win_filetime_from_systemtime {
     ($time:expr) => {
         match $time.duration_since(::std::time::SystemTime::UNIX_EPOCH) {
             Ok(dur) => ::tracelogging::_internal::filetime_from_duration_after_1970(dur),

--- a/etw/rust/tracelogging/tests/tests.rs
+++ b/etw/rust/tracelogging/tests/tests.rs
@@ -158,15 +158,15 @@ fn tag_encode() {
 }
 
 #[test]
-fn filetime_from_systemtime() {
+fn win_filetime_from_systemtime() {
     let epoch = std::time::SystemTime::UNIX_EPOCH;
     let d100 = std::time::Duration::from_secs(100);
     assert_eq!(
-        tlg::filetime_from_systemtime!(epoch + d100),
+        tlg::win_filetime_from_systemtime!(epoch + d100),
         tli::filetime_from_duration_after_1970(d100)
     );
     assert_eq!(
-        tlg::filetime_from_systemtime!(epoch - d100),
+        tlg::win_filetime_from_systemtime!(epoch - d100),
         tli::filetime_from_duration_before_1970(d100)
     );
 }

--- a/etw/rust/tracelogging_dynamic/Cargo.toml
+++ b/etw/rust/tracelogging_dynamic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracelogging_dynamic"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2021"
 authors = ["Microsoft"]
 license = "MIT"
@@ -28,4 +28,4 @@ default = ["etw"]
 etw = ["tracelogging/etw"] # Logging is enabled if windows && etw.
 
 [dependencies]
-tracelogging = { default-features = false, version = "= 1.0.1", path = "../tracelogging" }
+tracelogging = { default-features = false, version = "= 1.0.2", path = "../tracelogging" }

--- a/etw/rust/tracelogging_dynamic/src/builder.rs
+++ b/etw/rust/tracelogging_dynamic/src/builder.rs
@@ -76,6 +76,7 @@ use crate::provider::Provider;
 /// an error.
 ///
 /// Most ETW decoding tools are unable to decode an event with more than 128 fields.
+#[derive(Debug)]
 pub struct EventBuilder {
     meta: Vec<u8>,
     data: Vec<u8>,
@@ -857,10 +858,18 @@ impl EventBuilder {
             });
     }
 
-    /// Adds a FileTime field from an `i64` value.
+    /// Adds a
+    /// [FILETIME](https://learn.microsoft.com/en-us/windows/win32/api/minwinbase/ns-minwinbase-filetime)
+    /// field from an `i64` value.
     ///
     /// If out_type is Default, field will format as DateTime.
     /// Other useful out_type values: DateTimeCultureInsensitive, DateTimeUtc.
+    ///
+    /// You can use
+    /// [`win_filetime_from_systemtime!`](crate::win_filetime_from_systemtime) macro to
+    /// convert
+    /// [`std::time::SystemTime`](https://doc.rust-lang.org/std/time/struct.SystemTime.html)
+    /// values into `i64` FILETIME values.
     pub fn add_filetime(
         &mut self,
         field_name: &str,
@@ -873,10 +882,18 @@ impl EventBuilder {
             .raw_add_data_value(&field_value);
     }
 
-    /// Adds a FileTime variable-length array field from an iterator-of-`&i64` value.
+    /// Adds a
+    /// [FILETIME](https://learn.microsoft.com/en-us/windows/win32/api/minwinbase/ns-minwinbase-filetime)
+    /// variable-length array field from an iterator-of-`&i64` value.
     ///
     /// If out_type is Default, field will format as DateTime.
     /// Other useful out_type values: DateTimeCultureInsensitive, DateTimeUtc.
+    ///
+    /// You can use
+    /// [`win_filetime_from_systemtime!`](crate::win_filetime_from_systemtime) macro to
+    /// convert
+    /// [`std::time::SystemTime`](https://doc.rust-lang.org/std/time/struct.SystemTime.html)
+    /// values into `i64` FILETIME values.
     pub fn add_filetime_sequence<'a>(
         &mut self,
         field_name: &str,

--- a/etw/rust/tracelogging_dynamic/src/lib.rs
+++ b/etw/rust/tracelogging_dynamic/src/lib.rs
@@ -112,7 +112,7 @@
 //! ```
 
 // Re-exports from tracelogging:
-pub use tracelogging::filetime_from_systemtime;
+pub use tracelogging::win_filetime_from_systemtime;
 pub use tracelogging::Channel;
 pub use tracelogging::Guid;
 pub use tracelogging::InType;

--- a/etw/rust/tracelogging_dynamic/src/provider.rs
+++ b/etw/rust/tracelogging_dynamic/src/provider.rs
@@ -538,3 +538,17 @@ impl ProviderOptions {
         return self;
     }
 }
+
+impl fmt::Debug for ProviderOptions {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let callback_ptr = match self.callback_fn {
+            None => core::ptr::null(),
+            Some(p) => p as *const (),
+        };
+        return write!(
+            f,
+            "ProviderOptions {{ group_id: \"{:?}\", callback_fn: {:?}, callback_context: {:x} }}",
+            self.group_id, callback_ptr, self.callback_context
+        );
+    }
+}

--- a/etw/rust/tracelogging_dynamic/tests/tests.rs
+++ b/etw/rust/tracelogging_dynamic/tests/tests.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-//extern crate alloc;
-
 use core::pin::Pin;
 use tracelogging_dynamic::*;
 
@@ -14,7 +12,7 @@ fn provider() {
     );
 
     assert_eq!(
-        filetime_from_systemtime!(std::time::SystemTime::UNIX_EPOCH),
+        win_filetime_from_systemtime!(std::time::SystemTime::UNIX_EPOCH),
         0x19DB1DED53E8000
     );
 
@@ -52,10 +50,13 @@ fn provider() {
         assert_eq!(callback_context, 0xDEADBEEF);
     }
 
-    Provider::options()
-        .group_id(&Guid::zero())
-        .callback(my_callback, 1)
-        .group_id(&Guid::zero());
+    println!(
+        "{:?}",
+        Provider::options()
+            .group_id(&Guid::zero())
+            .callback(my_callback, 1)
+            .group_id(&Guid::zero())
+    );
 
     let mut provider = Box::pin(Provider::new());
     assert_eq!(provider.name(), "");
@@ -134,6 +135,7 @@ fn builder() {
     let mut p = Provider::new(); // Temporary that will be shadowed.
     let mut p = unsafe { Pin::new_unchecked(&mut p) };
     let mut b = EventBuilder::new();
+    println!("{:?}", b);
 
     unsafe {
         p.as_mut()

--- a/etw/rust/tracelogging_macros/Cargo.toml
+++ b/etw/rust/tracelogging_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracelogging_macros"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2021"
 authors = ["Microsoft"]
 license = "MIT"

--- a/etw/rust/tracelogging_macros/src/lib.rs
+++ b/etw/rust/tracelogging_macros/src/lib.rs
@@ -6,7 +6,7 @@
 //! Implements the macros that are exported by the tracelogging crate.
 
 extern crate proc_macro;
-use proc_macro::{Literal, Span, TokenStream, TokenTree};
+use proc_macro::{Span, TokenStream};
 
 use crate::event_generator::EventGenerator;
 use crate::event_info::EventInfo;
@@ -29,18 +29,6 @@ pub fn write_event(arg_tokens: TokenStream) -> TokenStream {
         Err(error_tokens) => error_tokens,
         Ok(prov) => EventGenerator::new(call_site).generate(prov),
     };
-}
-
-/// For testing: `define_provider2!(ignored)` --> nothing
-#[proc_macro]
-pub fn define_provider2(_arg_tokens: TokenStream) -> TokenStream {
-    return TokenStream::new();
-}
-
-/// For testing: `write_event2!(ignored)` --> `0`
-#[proc_macro]
-pub fn write_event2(_arg_tokens: TokenStream) -> TokenStream {
-    return TokenTree::Literal(Literal::u32_unsuffixed(0)).into();
 }
 
 // The tracelogging crate depends on the tracelogging_macros crate so the


### PR DESCRIPTION
- Rename `filetime_from_systemtime` to `win_filetime_from_systemtime`.
- Improve the doc comments for win_filetime_from_systemtime.
- Define `Debug` trait on `EventBuilder`.
- Define `Debug` trait on `ProviderOptions`.
- Remove "For testing" macros from `tracelogging_macros`.
- Version 1.0.2.