### PR TITLE
Added kernel_mode and user_mode features in tracelogging crate

### DIFF
--- a/etw/rust/tracelogging/Cargo.toml
+++ b/etw/rust/tracelogging/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracelogging"
-version = "1.2.1"
+version = "1.2.2"
 edition = "2021"
 authors = ["Microsoft"]
 license = "MIT"

--- a/etw/rust/tracelogging/Cargo.toml
+++ b/etw/rust/tracelogging/Cargo.toml
@@ -24,7 +24,7 @@ readme = "README.md"
 rust-version = "1.63"
 
 [features]
-default = ["macros", "etw"]
+default = ["etw", "macros"]
 etw = [] # Logging is enabled if windows && etw.
 kernel_mode = []
 macros = ["dep:tracelogging_macros"]

--- a/etw/rust/tracelogging/Cargo.toml
+++ b/etw/rust/tracelogging/Cargo.toml
@@ -24,9 +24,8 @@ readme = "README.md"
 rust-version = "1.63"
 
 [features]
-default = ["macros", "etw", "user_mode"]
+default = ["macros", "etw"]
 etw = [] # Logging is enabled if windows && etw.
-user_mode = []
 kernel_mode = []
 macros = ["dep:tracelogging_macros"]
 

--- a/etw/rust/tracelogging/Cargo.toml
+++ b/etw/rust/tracelogging/Cargo.toml
@@ -24,8 +24,10 @@ readme = "README.md"
 rust-version = "1.63"
 
 [features]
-default = ["etw", "macros"]
+default = ["macros", "etw", "user_mode"]
 etw = [] # Logging is enabled if windows && etw.
+user_mode = []
+kernel_mode = []
 macros = ["dep:tracelogging_macros"]
 
 [dependencies]

--- a/etw/rust/tracelogging/src/native.rs
+++ b/etw/rust/tracelogging/src/native.rs
@@ -20,7 +20,7 @@ pub enum NativeImplementation {
     /// Crate compiled for Windows (ETW) configuration (logging is performed via ETW
     /// APIs).
     Windows,
-    /// Create compiled for Windows (ETW) kernel-mode clients (logging is performed via
+    /// Crate compiled for Windows (ETW) kernel-mode clients (logging is performed via
     /// kernel-mode ETW APIs).
     /// 
     WindowsKernelMode,

--- a/etw/rust/tracelogging_dynamic/Cargo.toml
+++ b/etw/rust/tracelogging_dynamic/Cargo.toml
@@ -28,4 +28,4 @@ default = ["etw"]
 etw = ["tracelogging/etw"] # Logging is enabled if windows && etw.
 
 [dependencies]
-tracelogging = { default-features = false, version = "= 1.2.1", path = "../tracelogging" }
+tracelogging = { default-features = false, version = "= 1.2.2", path = "../tracelogging" }

--- a/etw/rust/tracelogging_macros/src/provider_generator.rs
+++ b/etw/rust/tracelogging_macros/src/provider_generator.rs
@@ -50,7 +50,6 @@ impl ProviderGenerator {
         let prov_tokens = self
             .prov_tree
             // static PROVIDER: ::tracelogging::Provider = unsafe { ... };
-            .add_ident("pub")
             .add_ident("static")
             .add_token(provider.symbol.clone())
             .add_punct(":")

--- a/etw/rust/tracelogging_macros/src/provider_generator.rs
+++ b/etw/rust/tracelogging_macros/src/provider_generator.rs
@@ -50,6 +50,7 @@ impl ProviderGenerator {
         let prov_tokens = self
             .prov_tree
             // static PROVIDER: ::tracelogging::Provider = unsafe { ... };
+            .add_ident("pub")
             .add_ident("static")
             .add_token(provider.symbol.clone())
             .add_punct(":")


### PR DESCRIPTION
**Why**
`tracelogging` crate cannot be used in kernel-mode code because of the reliance on Win32 APIs such as `EventRegister`.

**What Changed**
* Added optional `kernel_mode` feature which replaces Win32 APIs with kernel-mode APIs like `EtwRegister`
* Added optional `user_mode` feature for enabling Win32 APIs which is set by default to keep in parity with the existing configuration.
* Made provider static variable public for use across different files in the program.

**How Tested**
Added it to a kernel-mode driver built using [windows-drivers-rs](https://github.com/microsoft/windows-drivers-rs) and tested tracelogging prints on WinDbg.

**Usage**
Enabling `kernel_mode` feature will require the client to link with `NtosKrnl.lib` for definition of `Etw*` APIs.