### PR TITLE
traceloggingdynamic.py - fix exception on old python

### DIFF
--- a/etw/python/traceloggingdynamic/traceloggingdynamic.py
+++ b/etw/python/traceloggingdynamic/traceloggingdynamic.py
@@ -90,7 +90,7 @@ def providerid_from_name(providername : str) -> uuid.UUID:
     """
     # Note: This is almost (but not quite) compliant with RFC 4122 UUIDv5.
     # Not fixed here because it needs to match well-established behavior.
-    sha1 = hashlib.sha1(usedforsecurity = False)
+    sha1 = hashlib.new('sha1', usedforsecurity = False)
     sha1.update(b'\x48\x2C\x2D\xB2\xC3\x90\x47\xC8\x87\xF8\x1A\x15\xBF\xC1\x30\xFB')
     sha1.update(providername.upper().encode('utf_16_be'))
     arr = bytearray(sha1.digest()[0:16])


### PR DESCRIPTION
Fix exception on older builds of python where the algorithm-specific constructors don't recognize the usedforsecurity parameter. Fix by using the generic constructor which ignores unrecognized parameters. #58 