### PR TITLE
Fix build error of invalid bitwise operation between different enumerator types

### DIFF
--- a/etw/cpp/traceloggingdynamic/TraceLoggingDynamic.h
+++ b/etw/cpp/traceloggingdynamic/TraceLoggingDynamic.h
@@ -2165,7 +2165,7 @@ namespace tld
 
         void AddFieldInfo(UINT8 arity, Type type, UINT32 tags)
         {
-            _tld_ASSERT((type & InTypeMask) == (type & 0xff), "InType out of range");
+            _tld_ASSERT((type & (Type)InTypeMask) == (type & 0xff), "InType out of range");
             _tld_ASSERT((type & _tld_MAKE_TYPE(0, OutTypeMask)) == (Type)(type & 0xffffff00), "OutType out of range");
 
             UINT8 inMeta = arity | static_cast<UINT8>(type);


### PR DESCRIPTION
Fixed below error when compiling by clang-cl.exe on Windows, here is the original issue https://github.com/open-telemetry/opentelemetry-cpp/issues/3237.

```
TraceLoggingDynamic.h(2144,31): error: invalid bitwise operation between different enumeration types ('Type' and 'tld::InType')
 2144 |             _tld_ASSERT((type & InTypeMask) == (type & 0xff), "InType out of range");
```