### PR TITLE
Fix linker issues with Rust 1.87

### DIFF
--- a/etw/rust/tracelogging/Cargo.toml
+++ b/etw/rust/tracelogging/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracelogging"
-version = "1.2.3"
+version = "1.2.4"
 edition = "2021"
 authors = ["Microsoft"]
 license = "MIT"

--- a/etw/rust/tracelogging/src/changelog.rs
+++ b/etw/rust/tracelogging/src/changelog.rs
@@ -3,6 +3,10 @@
 #[allow(unused_imports)]
 use crate::*; // For docs
 
+/// # v1.2.4 (2025-05-16)
+/// - Fix linker issues when building with rustc 1.87
+pub mod v1_2_4 {}
+
 /// # v1.2.3 (2025-03-02)
 /// - Fix newer warnings about unsafe code
 /// - Update `tracelongging-macros` dependency to 1.2.1

--- a/etw/rust/tracelogging/src/native.rs
+++ b/etw/rust/tracelogging/src/native.rs
@@ -436,6 +436,7 @@ impl ProviderContextInner {
 }
 
 #[cfg(all(windows, feature = "etw", not(feature = "kernel_mode")))]
+#[link(name="OneCore_apiset")]
 extern "system" {
     fn EventUnregister(reg_handle: u64) -> u32;
     fn EventRegister(
@@ -444,6 +445,7 @@ extern "system" {
         outer_context: usize,
         reg_handle: &mut u64,
     ) -> u32;
+
     fn EventSetInformation(
         reg_handle: u64,
         information_class: u32,

--- a/etw/rust/tracelogging_dynamic/Cargo.toml
+++ b/etw/rust/tracelogging_dynamic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracelogging_dynamic"
-version = "1.2.3"
+version = "1.2.4"
 edition = "2021"
 authors = ["Microsoft"]
 license = "MIT"
@@ -28,4 +28,4 @@ default = ["etw"]
 etw = ["tracelogging/etw"] # Logging is enabled if windows && etw.
 
 [dependencies]
-tracelogging = { default-features = false, version = "= 1.2.3", path = "../tracelogging" }
+tracelogging = { default-features = false, version = "= 1.2.4", path = "../tracelogging" }

--- a/etw/rust/tracelogging_dynamic/src/changelog.rs
+++ b/etw/rust/tracelogging_dynamic/src/changelog.rs
@@ -3,6 +3,10 @@
 #[allow(unused_imports)]
 use crate::*; // For docs
 
+/// # v1.2.4 (2025-05-16)
+/// - Fix linker issues when building with rustc 1.87
+pub mod v1_2_4 {}
+
 /// # v1.2.3 (2025-03-02)
 /// - Fix newer warnings about unsafe code
 /// - Update `tracelongging` dependency to 1.2.3


### PR DESCRIPTION
Fixes #76 

Linking against "onecore_apiset" will mean the code will run on whichever version of the Windows SDK is being used, but maybe not different versions if the API set host changes. In practice, the ETW functions are all in kernelbase.dll and don't jump around to different hosts, so this will just link directly against kernelbase.dll and skip all the forwarding.