### PR TITLE
Fix: TraceLoggingDynamic.h failing under /Zc:preprocessor on msvc

### DIFF
--- a/etw/cpp/traceloggingdynamic/TraceLoggingDynamic.h
+++ b/etw/cpp/traceloggingdynamic/TraceLoggingDynamic.h
@@ -632,10 +632,7 @@ namespace tld
 
 #ifndef _tld_ASSERT
   #if TLD_DEBUG
-    // The below lambda should compile on both msvc's older preprocessor (i.e. /Zc:preprocessor-) and also msvc's modern preprocessor (/Zc:preprocessor)
-    // However, it does require at least C++11 support due to the use of lambdas. 
-    // If you need to support pre-C++11 compilers, you'll need to #define TLD_DEBUG 0 or #define _tld_ASSERT to something else before including this header.
-    #define _tld_ASSERT(exp, str) ((void)(!(exp) ? []()  { __annotation(L"Debug", L"AssertFail", L"TraceLogging: " #exp L" : " #str); DbgRaiseAssertionFailure(); return 0; }() : 0))
+    #define _tld_ASSERT(exp, str) ((void)(!(exp) ? (__annotation(L"Debug", L"AssertFail", L"TraceLogging: " #exp L" : " #str), DbgRaiseAssertionFailure(), 0) : 0))
   #else // TLD_DEBUG
     #define _tld_ASSERT(exp, str) ((void)0)
   #endif // TLD_DEBUG

--- a/etw/cpp/traceloggingdynamic/TraceLoggingDynamic.h
+++ b/etw/cpp/traceloggingdynamic/TraceLoggingDynamic.h
@@ -632,7 +632,7 @@ namespace tld
 
 #ifndef _tld_ASSERT
   #if TLD_DEBUG
-    #define _tld_ASSERT(exp, str) ((void)(!(exp) ? (__annotation(L"Debug", L"AssertFail", L"TraceLogging: " #exp L" : " #str), DbgRaiseAssertionFailure(), 0) : 0))
+    #define _tld_ASSERT(exp, str) ((void)(!(exp) ? (__annotation(L"Debug", L"AssertFail", L"TraceLogging: " #exp L" : " str), DbgRaiseAssertionFailure(), 0) : 0))
   #else // TLD_DEBUG
     #define _tld_ASSERT(exp, str) ((void)0)
   #endif // TLD_DEBUG

--- a/etw/cpp/traceloggingdynamic/TraceLoggingDynamic.h
+++ b/etw/cpp/traceloggingdynamic/TraceLoggingDynamic.h
@@ -632,7 +632,10 @@ namespace tld
 
 #ifndef _tld_ASSERT
   #if TLD_DEBUG
-    #define _tld_ASSERT(exp, str) ((void)(!(exp) ? (__annotation(L"Debug", L"AssertFail", L"TraceLogging: " L#exp L" : " L##str), DbgRaiseAssertionFailure(), 0) : 0))
+    // The below lambda should compile on both msvc's older preprocessor (i.e. /Zc:preprocessor-) and also msvc's modern preprocessor (/Zc:preprocessor)
+    // However, it does require at least C++11 support due to the use of lambdas. 
+    // If you need to support pre-C++11 compilers, you'll need to #define TLD_DEBUG 0 or #define _tld_ASSERT to something else before including this header.
+    #define _tld_ASSERT(exp, str) ((void)(!(exp) ? []()  { __annotation(L"Debug", L"AssertFail", L"TraceLogging: " #exp L" : " #str); DbgRaiseAssertionFailure(); return 0; }() : 0))
   #else // TLD_DEBUG
     #define _tld_ASSERT(exp, str) ((void)0)
   #endif // TLD_DEBUG


### PR DESCRIPTION
* Replace the non-conformant ```L#exp``` and ```L##str``` with ```#exp``` and ```#str```, since there is already a proceeding string literal that they will be combined with; per https://learn.microsoft.com/en-us/cpp/preprocessor/preprocessor-experimental-overview?view=msvc-170#lval, as well as via [Compiler Explorer](https://godbolt.org/z/T8K1sjefT) , this should compile with both the old and new preprocessor (as well as being more compatible with clang, gcc, and so on.
* ~~Also replace the parentheses shenanigans (that really shouldn't compile!) with immediately evaluated Lambda shenanigans that are conformant preprocessor compatible. I'm assuming TraceLoggingDynamic.h already requires C++11, but if it doesn't, we could make TLD_DEBUG default to 0 for pre-C++11 compiler versions.~~

Closes #79 